### PR TITLE
Install ms-gsl from pix for mac-arm

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -313,6 +313,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h91ba8db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-h41d338b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ms-gsl-4.0.0-h420ef59_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
@@ -6984,6 +6985,22 @@ packages:
   license_family: MIT
   size: 24981
   timestamp: 1682992435386
+- kind: conda
+  name: ms-gsl
+  version: 4.0.0
+  build: h420ef59_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ms-gsl-4.0.0-h420ef59_1.conda
+  sha256: 44dc0789c08b943a4c6ee5da93b489cde5503e22d6257448ad381fcffd487dca
+  md5: 37d23e711a114938f1936b0e7880e3cb
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 25405
+  timestamp: 1718740558325
 - kind: conda
   name: ms-gsl
   version: 4.0.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,6 +30,7 @@ ezc3d = "1.5.9.*"
 fmt = "10.2.1.*"
 libdeflate = ">=1.19,<2"
 librerun-sdk = ">=0.16,<0.17"
+ms-gsl = ">=4.0.0,<4.1"
 nlohmann_json = "3.11.*"
 openssl = ">=3.2.1,<3.3"
 re2 = "2023.9.1.*"
@@ -50,7 +51,7 @@ install_dispenso = { cmd = "git clone https://github.com/facebookincubator/dispe
 ], outputs = [
     "$CONDA_PREFIX/lib/cmake/Dispenso-1.2.0/DispensoConfig.cmake",
 ] }
-install_OpenFBX = { cmd = "git clone https://github.com/jeongseok-meta/OpenFBX.git && cd OpenFBX && git checkout 02dcab9ff96b7377c8a23237667cc4eb0a5c37c9 && cd .. && cmake OpenFBX -B OpenFBX/build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release && cmake --build OpenFBX/build --target install --parallel && rm -rf OpenFBX", cwd = ".deps", depends_on = [
+install_OpenFBX = { cmd = "git clone https://github.com/jeongseok-meta/OpenFBX.git && cd OpenFBX && git checkout 16a386610dd42abb2fcba160e3de489e8aac0929 && cd .. && cmake OpenFBX -B OpenFBX/build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release && cmake --build OpenFBX/build --target install --parallel && rm -rf OpenFBX", cwd = ".deps", depends_on = [
     "create_deps_dir",
 ], outputs = [
     "$CONDA_PREFIX/share/openfbx/openfbxConfig.cmake",
@@ -64,11 +65,6 @@ install_sophus = { cmd = "git clone https://github.com/strasdat/Sophus.git -b '1
     "create_deps_dir",
 ], outputs = [
     "$CONDA_PREFIX/share/sophus/cmake/SophusConfig.cmake",
-] }
-install_ms_gsl = { cmd = "git clone https://github.com/microsoft/GSL.git -b 'v4.0.0' --single-branch --depth 1 && cmake GSL -B GSL/build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DGSL_TEST=OFF && cmake --build GSL/build --target install --parallel && rm -rf GSL", cwd = ".deps", depends_on = [
-    "create_deps_dir",
-], outputs = [
-    "$CONDA_PREFIX/share/cmake/Microsoft.GSL/Microsoft.GSLConfig.cmake",
 ] }
 install_deps = { depends_on = [
     "install_drjit",
@@ -108,7 +104,6 @@ install = { cmd = "cmake --build build -j --target install", depends_on = [
 clang-format-18 = ">=18.1.2,<19"
 
 [target.linux-64.dependencies]
-ms-gsl = ">=4.0.0,<4.1"
 pytorch = ">=2.1.2,<2.2"
 sophus = ">=22.10,<23"
 sysroot_linux-64 = ">=2.28"
@@ -141,7 +136,6 @@ install_deps = { depends_on = [
     "install_OpenFBX",
     "install_fx_gltf",
     "install_sophus",
-    "install_ms_gsl",
     "remove_deps_dir",
 ] }
 lint = { cmd = "clang-format-18 -i axel/**/*.h axel/**/*.cpp momentum/**/*.h momentum/**/*.cpp pymomentum/**/*.h pymomentum/**/*.cpp" }
@@ -155,7 +149,6 @@ build_pymomentum = { cmd = "pip install -e .", depends_on = ["install_deps"] }
 #=========
 
 [target.win-64.dependencies]
-ms-gsl = ">=4.0.0,<4.1"
 pytorch-cuda = ">=12.1,<13"
 
 [target.win-64.tasks]
@@ -169,7 +162,7 @@ install_dispenso = { cmd = "git clone https://github.com/facebookincubator/dispe
 ], outputs = [
     "$CONDA_PREFIX/lib/cmake/Dispenso-1.2.0/DispensoConfig.cmake",
 ] }
-install_OpenFBX = { cmd = "git clone https://github.com/jeongseok-meta/OpenFBX.git && cd OpenFBX && git checkout 02dcab9ff96b7377c8a23237667cc4eb0a5c37c9 && cd .. && cmake OpenFBX -B OpenFBX/build -G 'Visual Studio 17 2022' -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX && cmake --build OpenFBX/build --target install --config Release --parallel && rm -rf OpenFBX", cwd = ".deps", depends_on = [
+install_OpenFBX = { cmd = "git clone https://github.com/jeongseok-meta/OpenFBX.git && cd OpenFBX && git checkout 16a386610dd42abb2fcba160e3de489e8aac0929 && cd .. && cmake OpenFBX -B OpenFBX/build -G 'Visual Studio 17 2022' -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX && cmake --build OpenFBX/build --target install --config Release --parallel && rm -rf OpenFBX", cwd = ".deps", depends_on = [
     "create_deps_dir",
 ], outputs = [
     "$CONDA_PREFIX/share/openfbx/openfbxConfig.cmake",


### PR DESCRIPTION
Summary: Installing ms-gsl from Pixi is now supported on mac-arm as well, by https://github.com/conda-forge/ms-gsl-feedstock/pull/1

Differential Revision: D58748282


