### PR TITLE
Prevent recursive GIL release.

### DIFF
--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -324,6 +324,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def_static(
           "from_gltf_bytes",
           &loadGLTFCharacterFromBytes,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Load a character from a gltf byte array.
 
 :parameter gltf_bytes: A :class:`bytes` containing the GLTF JSON/messagepack data.
@@ -334,6 +335,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def_static(
           "to_gltf",
           &toGLTF,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Serialize a character as a GLTF using dictionary form.
 
 :parameter character: A valid character.
@@ -347,6 +349,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def_static(
           "load_fbx",
           &loadFBXCharacterFromFile,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Load a character from an FBX file.  Optionally pass in a separate model definition and locators file.
 
 :parameter fbx_filename: .fbx file that contains the skeleton and skinned mesh; e.g. blue_man_s0.fbx.
@@ -362,6 +365,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def_static(
           "load_fbx_with_motion",
           &loadFBXCharacterWithMotionFromFile,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Load a character and animation curves from an FBX file.
 
 :parameter fbx_filename: .fbx file that contains the skeleton and skinned mesh; e.g. blue_man_s0.fbx.
@@ -372,6 +376,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def_static(
           "load_fbx_with_motion_from_bytes",
           &loadFBXCharacterWithMotionFromBytes,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Load a character and animation curves from an FBX file.
 
 :parameter fbx_bytes: A Python bytes that is an .fbx file containing the skeleton and skinned mesh.
@@ -383,6 +388,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def_static(
           "load_fbx_from_bytes",
           &pymomentum::loadFBXCharacterFromBytes,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Load a character from byte array for an FBX file.
 
 :parameter fbx_bytes: An array of bytes in FBX format.
@@ -393,6 +399,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def(
           "load_locators",
           &pymomentum::loadLocatorsFromFile,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Load locators from a .locators file.
 
 :parameter character: The character to map the locators onto.
@@ -403,6 +410,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def(
           "load_locators_from_bytes",
           &pymomentum::loadLocatorsFromBytes,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Load locators from a .locators file.
 
 :parameter character: The character to map the locators onto.
@@ -413,6 +421,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def(
           "load_model_definition",
           &pymomentum::loadConfigFromFile,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Load a model definition from a .model file.  This defines the parameter transform, model parameters, and joint limits.
 
 :parameter character: The character containing a valid skeleton.
@@ -423,6 +432,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def(
           "load_model_definition_from_bytes",
           &pymomentum::loadConfigFromBytes,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Load a model definition from a .model file.  This defines the parameter transform, model parameters, and joint limits.
 
 :parameter character: The character containing a valid skeleton.
@@ -433,6 +443,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def_static(
           "load_gltf_with_motion",
           &loadCharacterWithMotion,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Load a character and a motion sequence from a gltf file.
 
 :parameter gltfFilename: A .gltf file; e.g. character_s0.glb.
@@ -443,6 +454,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def_static(
           "load_gltf",
           &loadGLTFCharacterFromFile,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Load a character from a gltf file.
 
 :parameter path: A .gltf file; e.g. character_s0.glb.
@@ -452,6 +464,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def_static(
           "save_gltf",
           &saveGLTFCharacterToFile,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Save a character to a gltf file.
 
 :parameter path: A .gltf export filename.
@@ -472,6 +485,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def_static(
           "save_gltf_from_skel_states",
           &saveGLTFCharacterToFileFromSkelStates,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Save a character to a gltf file.
 
 :parameter path: A .gltf export filename.
@@ -491,6 +505,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       .def_static(
           "save_fbx",
           &saveFBXCharacterToFile,
+          py::call_guard<py::gil_scoped_release>(),
           R"(Save a character to an fbx file.
 
 :parameter path: An .fbx export filename.

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -62,7 +62,6 @@ momentum::Character loadGLTFCharacterFromBytes(const pybind11::bytes& bytes) {
     throw std::runtime_error("Unable to extract contents from bytes.");
   }
 
-  pybind11::gil_scoped_release release;
   return momentum::loadGltfCharacter(
       gsl::make_span<const std::byte>(data, length));
 }
@@ -196,7 +195,6 @@ momentum::Character loadFBXCharacterFromFile(
     const std::optional<std::string>& configPath,
     const std::optional<std::string>& locatorsPath,
     bool permissive) {
-  pybind11::gil_scoped_release release;
   momentum::Character result = momentum::loadOpenFbxCharacter(
       filesystem::path(fbxPath), keepLocators, permissive);
   if (configPath && !configPath->empty()) {
@@ -224,7 +222,6 @@ std::tuple<momentum::Character, std::vector<Eigen::MatrixXf>, float>
 loadFBXCharacterWithMotionFromFile(
     const std::string& fbxPath,
     bool permissive) {
-  pybind11::gil_scoped_release release;
   auto [character, motion, fps] = momentum::loadOpenFbxCharacterWithMotion(
       filesystem::path(fbxPath), keepLocators, permissive);
   transposeMotionInPlace(motion);
@@ -235,7 +232,6 @@ std::tuple<momentum::Character, std::vector<Eigen::MatrixXf>, float>
 loadFBXCharacterWithMotionFromBytes(
     const py::bytes& fbxBytes,
     bool permissive) {
-  pybind11::gil_scoped_release release;
   auto [character, motion, fps] = momentum::loadOpenFbxCharacterWithMotion(
       toSpan<std::byte>(fbxBytes), keepLocators, permissive);
   transposeMotionInPlace(motion);
@@ -245,7 +241,6 @@ loadFBXCharacterWithMotionFromBytes(
 momentum::Character loadLocatorsFromFile(
     const momentum::Character& character,
     const std::string& locatorsPath) {
-  pybind11::gil_scoped_release release;
   if (locatorsPath.empty()) {
     throw std::runtime_error("Missing locators path.");
   }
@@ -262,7 +257,6 @@ momentum::Character loadLocatorsFromFile(
 momentum::Character loadConfigFromFile(
     const momentum::Character& character,
     const std::string& configPath) {
-  pybind11::gil_scoped_release release;
   if (configPath.empty()) {
     throw std::runtime_error("Missing model definition path.");
   }
@@ -277,7 +271,6 @@ momentum::Character loadConfigFromFile(
 momentum::Character loadFBXCharacterFromBytes(
     const pybind11::bytes& bytes,
     bool permissive) {
-  pybind11::gil_scoped_release release;
   return momentum::loadOpenFbxCharacter(
       toSpan<std::byte>(bytes), keepLocators, permissive);
 }
@@ -285,7 +278,6 @@ momentum::Character loadFBXCharacterFromBytes(
 momentum::Character loadConfigFromBytes(
     const momentum::Character& character,
     const pybind11::bytes& bytes) {
-  pybind11::gil_scoped_release release;
   momentum::Character result = character;
   std::tie(result.parameterTransform, result.parameterLimits) =
       momentum::loadModelDefinition(
@@ -296,7 +288,6 @@ momentum::Character loadConfigFromBytes(
 momentum::Character loadLocatorsFromBytes(
     const momentum::Character& character,
     const pybind11::bytes& bytes) {
-  pybind11::gil_scoped_release release;
   momentum::Character result = character;
   auto locators = momentum::loadLocatorsFromBuffer(
       toSpan<std::byte>(bytes),
@@ -309,13 +300,11 @@ momentum::Character loadLocatorsFromBytes(
 
 std::shared_ptr<const momentum::Mppca> loadPosePriorFromFile(
     const std::string& path) {
-  pybind11::gil_scoped_release release;
   return momentum::loadMppca(path);
 }
 
 std::shared_ptr<const momentum::Mppca> loadPosePriorFromBytes(
     const py::bytes& bytes) {
-  pybind11::gil_scoped_release release;
   return momentum::loadMppca(toSpan<unsigned char>(bytes));
 }
 
@@ -323,7 +312,6 @@ std::shared_ptr<momentum::BlendShape> loadBlendShapeFromFile(
     const std::string& path,
     int nExpectedShapes,
     int nExpectedVertices) {
-  pybind11::gil_scoped_release release;
   auto result =
       momentum::loadBlendShape(path, nExpectedShapes, nExpectedVertices);
   if (result.getBaseShape().empty()) {


### PR DESCRIPTION
Summary:
When calling load_fbx with additional arguments (locators and .model file) we end up accidentally releasing the GIL multiple times because loadFBX calls loadLocators.

To prevent this, move the GIL release to a call guard where the Python file is defined.

Reviewed By: jeongseok-meta

Differential Revision: D58760470


