### PR TITLE
Add GitHub CI job to update pixi lock file automatically

### DIFF
--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -1,0 +1,36 @@
+name: Update Lock Files
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 5 1 * *  # Runs at 05:00, on day 1 of the month
+
+jobs:
+  pixi-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          run-install: false
+      - name: Update lockfiles
+        run: |
+          pixi global install pixi-diff-to-markdown
+          pixi update --json --no-install | pixi-diff-to-markdown >> diff.md
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update pixi lockfile
+          title: Update pixi lockfile
+          body-path: diff.md
+          branch: update-pixi
+          base: main
+          labels: pixi
+          delete-branch: true
+          add-paths: pixi.lock


### PR DESCRIPTION
Summary: to automatically update the Pixi lock file by following these instructions: https://pixi.sh/dev/advanced/updates_github_actions/

Reviewed By: juliencbmeta

Differential Revision: D58800803
