### PR TITLE
Use gsl::span to avoid unnecessary data copy

### DIFF
--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -185,7 +185,7 @@ static const auto kUnitCubeGreen = createUnitCube(Eigen::Vector3b(0, 255, 0));
 void addActorAnimationToModel(
     fx::gltf::Document& model,
     const float fps,
-    const std::vector<std::vector<Marker>>& markerSequence,
+    gsl::span<const std::vector<momentum::Marker>> markerSequence,
     const GltfBuilder::MarkerMesh markerMesh,
     const std::string& animName) {
   if (markerSequence.empty())
@@ -845,7 +845,7 @@ std::vector<size_t> GltfBuilder::getCharacterMotions(const std::string& characte
 
 void GltfBuilder::addMarkerSequence(
     const float fps,
-    const std::vector<std::vector<Marker>>& markers,
+    gsl::span<const std::vector<momentum::Marker>> markers,
     const MarkerMesh markerMesh,
     const std::string& animName) {
   setFps(fps);

--- a/momentum/io/gltf/gltf_builder.hpp
+++ b/momentum/io/gltf/gltf_builder.hpp
@@ -86,7 +86,7 @@ class GltfBuilder final {
   /// @param[in] animName Optional parameter specifying the animation name (default is "default").
   void addMarkerSequence(
       const float fps,
-      const std::vector<std::vector<Marker>>& markerSequence,
+      gsl::span<const std::vector<momentum::Marker>> markerSequence,
       const MarkerMesh markerMesh = MarkerMesh::None,
       const std::string& animName = "default");
 

--- a/momentum/marker_tracking/app_utils.cpp
+++ b/momentum/marker_tracking/app_utils.cpp
@@ -150,7 +150,7 @@ void saveMotion(
     const momentum::Character& character,
     const momentum::ModelParameters& identity,
     Eigen::MatrixXf& finalMotion,
-    const std::vector<std::vector<momentum::Marker>>& markerData,
+    gsl::span<const std::vector<momentum::Marker>> markerData,
     const double fps,
     const bool saveMarkerMesh) {
   ModelParameters id =

--- a/momentum/marker_tracking/app_utils.h
+++ b/momentum/marker_tracking/app_utils.h
@@ -42,7 +42,7 @@ void saveMotion(
     const momentum::Character& character,
     const momentum::ModelParameters& identity,
     Eigen::MatrixXf& finalMotion,
-    const std::vector<std::vector<momentum::Marker>>& markerData,
+    gsl::span<const std::vector<momentum::Marker>> markerData,
     double fps,
     bool saveMarkerMesh = true);
 

--- a/momentum/marker_tracking/process_markers.cpp
+++ b/momentum/marker_tracking/process_markers.cpp
@@ -106,7 +106,8 @@ void processMarkerFile(
         character,
         identity,
         finalMotion,
-        {actor->frames.begin() + firstFrame, actor->frames.begin() + lastFrame},
+        gsl::span<const std::vector<momentum::Marker>>(
+            actor->frames.data() + firstFrame, actor->frames.data() + lastFrame),
         actor->fps);
     MT_LOGI("{} saved", outputFile);
   } catch (std::exception& e) {


### PR DESCRIPTION
Summary: Optimize the saveMotion function by using gsl::span<const std::vector<T>> to avoid data copying

Differential Revision: D58802901


