### PR TITLE
Use sophus package of Pixi

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -174,7 +174,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.5.1-h9b69904_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.0-hdb0a2a9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sophus-22.10-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sophus-1!1.24.6-hac33072_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.12.0-hd2e6256_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/suitesparse-7.7.0-hf4753ba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pypyh2585a3b_103.conda
@@ -349,6 +349,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.5.1-h156473d_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.0-hd04f947_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sophus-1!1.24.6-h00cdb27_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.12.0-he64bfa9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/suitesparse-7.7.0-hf6fcff2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pypyh2585a3b_103.conda
@@ -519,6 +520,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.13.1-py312h1f4e10d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.0-hfb803bf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sophus-1!1.24.6-he0c23c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.12.0-h64d2f7d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
@@ -8509,20 +8511,56 @@ packages:
   timestamp: 1712591680669
 - kind: conda
   name: sophus
-  version: '22.10'
-  build: h27087fc_0
+  version: 1!1.24.6
+  build: h00cdb27_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sophus-1!1.24.6-h00cdb27_1.conda
+  sha256: c314da8813ca2a8c021618ec41b6c13c89b409d1f3e6950efc17b044940f0fd5
+  md5: 52fd5a6d7bb2f8f6748d5210519a61fe
+  depends:
+  - __osx >=11.0
+  - eigen >=3.3
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 49589
+  timestamp: 1719292168756
+- kind: conda
+  name: sophus
+  version: 1!1.24.6
+  build: hac33072_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sophus-22.10-h27087fc_0.tar.bz2
-  sha256: 688c7c8b0db4f458aadec832a6d8f3c5cff175cc11ec0b6daea7c736dc430e64
-  md5: bb2aa80faa4fc96ad0aed57f60965170
+  url: https://conda.anaconda.org/conda-forge/linux-64/sophus-1!1.24.6-hac33072_1.conda
+  sha256: 61af844b4e5d653f1396f061181e1e044ad3d2bdbe76c71f3944169f4f31ad67
+  md5: b1c69b4e35dd860c3012994ed83349e5
   depends:
   - eigen >=3.3
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
-  size: 48681
-  timestamp: 1665496751889
+  size: 49466
+  timestamp: 1719292378317
+- kind: conda
+  name: sophus
+  version: 1!1.24.6
+  build: he0c23c2_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/sophus-1!1.24.6-he0c23c2_1.conda
+  sha256: b94214736d98fb74d944ec1c639ab4a51025bc1ee34d4054f5958cfd50ee9c78
+  md5: 8395183e8983dc642f0ee82dc929317d
+  depends:
+  - eigen >=3.3
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 49786
+  timestamp: 1719293157202
 - kind: conda
   name: spdlog
   version: 1.12.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -37,6 +37,7 @@ ms-gsl = ">=4.0.0,<4.1"
 nlohmann_json = "3.11.*"
 openssl = ">=3.2.1,<3.3"
 re2 = "2023.9.1.*"
+sophus = ">=1!1.24.6,<1!1.25"
 spdlog = ">=1.12.0,<1.13"
 zlib = ">=1.2.13,<1.3"
 
@@ -49,14 +50,8 @@ install_OpenFBX = { cmd = "git clone https://github.com/nem0/OpenFBX.git && cd O
 ], outputs = [
     "$CONDA_PREFIX/share/openfbx/openfbxConfig.cmake",
 ] }
-install_sophus = { cmd = "git clone https://github.com/strasdat/Sophus.git -b '1.22.10' --single-branch --depth 1 && cmake Sophus -B Sophus/build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DBUILD_SOPHUS_TESTS=OFF -DBUILD_SOPHUS_EXAMPLES=OFF && cmake --build Sophus/build --target install --parallel && rm -rf Sophus", cwd = ".deps", depends_on = [
-    "create_deps_dir",
-], outputs = [
-    "$CONDA_PREFIX/share/sophus/cmake/SophusConfig.cmake",
-] }
 install_deps = { depends_on = [
     "install_OpenFBX",
-    "install_sophus",
     "remove_deps_dir",
 ] }
 reinstall_deps = { depends_on = ["remove_deps_dir", "install_deps"] }
@@ -90,7 +85,6 @@ clang-format-18 = ">=18.1.2,<19"
 
 [target.linux-64.dependencies]
 pytorch = ">=2.1.2,<2.2"
-sophus = ">=22.10,<23"
 sysroot_linux-64 = ">=2.28"
 
 [target.linux-64.tasks]
@@ -114,7 +108,6 @@ pytorch = ">=2.1.2,<2.2"
 [target.osx-arm64.tasks]
 install_deps = { depends_on = [
     "install_OpenFBX",
-    "install_sophus",
     "remove_deps_dir",
 ] }
 lint = { cmd = "clang-format-18 -i axel/**/*.h axel/**/*.cpp momentum/**/*.h momentum/**/*.cpp pymomentum/**/*.h pymomentum/**/*.cpp" }
@@ -135,11 +128,6 @@ install_OpenFBX = { cmd = "git clone https://github.com/nem0/OpenFBX.git && cd O
     "create_deps_dir",
 ], outputs = [
     "$CONDA_PREFIX/share/openfbx/openfbxConfig.cmake",
-] }
-install_sophus = { cmd = "git clone https://github.com/strasdat/Sophus.git -b '1.22.10' --single-branch --depth 1 && cmake Sophus -B Sophus/build -G 'Visual Studio 17 2022' -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_SOPHUS_TESTS=OFF -DBUILD_SOPHUS_EXAMPLES=OFF && cmake --build Sophus/build --target install --config Release --parallel && rm -rf Sophus", cwd = ".deps", depends_on = [
-    "create_deps_dir",
-], outputs = [
-    "$CONDA_PREFIX/share/sophus/cmake/SophusConfig.cmake",
 ] }
 configure = { cmd = "cmake -S . -B build -G 'Visual Studio 17 2022' -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_SHARED_LIBS=OFF -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON -DMOMENTUM_BUILD_TESTING=ON -DMOMENTUM_BUILD_EXAMPLES=ON -DMOMENTUM_BUILD_PYMOMENTUM=OFF", depends_on = [
     "install_deps",


### PR DESCRIPTION
Summary:
The Sophus package of Pixi now supports all the PC platforms that Momentum supports, so no need to build from source:

- osx_arm64: https://github.com/conda-forge/sophus-feedstock/pull/2
- win64: https://github.com/conda-forge/sophus-feedstock/pull/3

Differential Revision: D58916211


