### PR TITLE
Use OpenFBX package of Pixi

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -151,6 +151,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.11.3-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openblas-0.3.27-pthreads_h7a3da1a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openfbx-0.9-h1f05711_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.2-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.0-h17fec99_1.conda
@@ -326,6 +327,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openblas-0.3.27-openmp_h55c453e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openfbx-0.9-hf252ed8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.2-hfb2fe0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.0-h4aad248_1.conda
@@ -499,6 +501,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/nlohmann_json-3.11.3-h1537add_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openfbx-0.9-he75f1b5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.2-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.0-h7e885a9_1.conda
@@ -7428,6 +7431,56 @@ packages:
   license_family: BSD
   size: 5730600
   timestamp: 1712364465401
+- kind: conda
+  name: openfbx
+  version: '0.9'
+  build: h1f05711_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openfbx-0.9-h1f05711_1.conda
+  sha256: a190f8aa76349aa7081b6736a24388fd6243031313329a984c841b8bed35b17c
+  md5: 5064c895b9fbc315f82f871940eb3cb2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libdeflate >=1.20,<1.21.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  size: 86796
+  timestamp: 1719862640030
+- kind: conda
+  name: openfbx
+  version: '0.9'
+  build: he75f1b5_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openfbx-0.9-he75f1b5_1.conda
+  sha256: afc9d78d806ff2da853d6462661eece89637e1ea31bdc097bc6ba9c2167604fd
+  md5: eaf5cf3fce547f518c0c0737e15dfaff
+  depends:
+  - libdeflate >=1.20,<1.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  size: 134128
+  timestamp: 1719862823630
+- kind: conda
+  name: openfbx
+  version: '0.9'
+  build: hf252ed8_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openfbx-0.9-hf252ed8_1.conda
+  sha256: 600501deab04c9e88d11bf4a130139e3a2255968ce8c04a343658799d605f4af
+  md5: e70ad3843b044991bc110680396420b1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libdeflate >=1.20,<1.21.0a0
+  license: MIT
+  size: 78227
+  timestamp: 1719862696634
 - kind: conda
   name: openjpeg
   version: 2.5.2

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 description = "A library providing foundational algorithms for human kinematic motion and numerical optimization solvers to apply human motion in various applications"
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/facebookincubator/momentum"
+homepage = "https://facebookincubator.github.io/momentum/"
 repository = "https://github.com/facebookincubator/momentum"
 
 [build-dependencies]
@@ -31,7 +31,6 @@ ezc3d = "1.5.9.*"
 drjit-cpp = ">=0.4.6,<0.5"
 fmt = "10.2.1.*"
 fx-gltf = ">=2.0.0,<2.1"
-libdeflate = ">=1.19,<2"
 librerun-sdk = ">=0.16,<0.17"
 ms-gsl = ">=4.0.0,<4.1"
 nlohmann_json = "3.11.*"
@@ -39,24 +38,11 @@ openssl = ">=3.2.1,<3.3"
 re2 = "2023.9.1.*"
 sophus = ">=1!1.24.6,<1!1.25"
 spdlog = ">=1.12.0,<1.13"
+openfbx = ">=0.9,<1"
 
 [tasks]
-clean = { cmd = "rm -rf build && rm -rf .deps && rm -rf .pixi && rm pixi.lock" }
-create_deps_dir = { cmd = "mkdir -p .deps" }
-remove_deps_dir = { cmd = "rm -rf .deps" }
-install_OpenFBX = { cmd = "git clone https://github.com/nem0/OpenFBX.git && cd OpenFBX && git checkout 932dbba1fe38b821d4de9b9ba64070e00e65549f && cd .. && cmake OpenFBX -B OpenFBX/build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DOFBX_DOUBLE_PRECISION=ON && cmake --build OpenFBX/build --target install --parallel && rm -rf OpenFBX", cwd = ".deps", depends_on = [
-    "create_deps_dir",
-], outputs = [
-    "$CONDA_PREFIX/share/openfbx/openfbxConfig.cmake",
-] }
-install_deps = { depends_on = [
-    "install_OpenFBX",
-    "remove_deps_dir",
-] }
-reinstall_deps = { depends_on = ["remove_deps_dir", "install_deps"] }
-configure = { cmd = "cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON -DMOMENTUM_BUILD_TESTING=ON -DMOMENTUM_BUILD_EXAMPLES=ON -DMOMENTUM_BUILD_PYMOMENTUM=ON", depends_on = [
-    "install_deps",
-], inputs = [
+clean = { cmd = "rm -rf build && rm -rf .pixi && rm pixi.lock" }
+configure = { cmd = "cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON -DMOMENTUM_BUILD_TESTING=ON -DMOMENTUM_BUILD_EXAMPLES=ON -DMOMENTUM_BUILD_PYMOMENTUM=ON", inputs = [
     "CMakeLists.txt",
 ] }
 build = { cmd = "cmake --build build -j --target all", depends_on = [
@@ -88,10 +74,7 @@ sysroot_linux-64 = ">=2.28"
 
 [target.linux-64.tasks]
 lint = { cmd = "clang-format-18 -i axel/**/*.h axel/**/*.cpp momentum/**/*.h momentum/**/*.cpp pymomentum/**/*.h pymomentum/**/*.cpp" }
-install_deps = { depends_on = [
-    "install_OpenFBX",
-] }
-build_pymomentum = { cmd = "pip install -e .", depends_on = ["install_deps"] }
+build_pymomentum = { cmd = "pip install -e ." }
 test_pymomentum = { cmd = "pytest pymomentum/test/test_closest_points.py pymomentum/test/test_fbx.py pymomentum/test/test_parameter_transform.py pymomentum/test/test_quaternion.py pymomentum/test/test_skel_state.py pymomentum/test/test_skeleton.py", env = { MOMENTUM_MODELS_PATH = "momentum/" } }
 
 #============
@@ -105,15 +88,11 @@ clang-format-18 = ">=18.1.2,<19"
 pytorch = ">=2.1.2,<2.2"
 
 [target.osx-arm64.tasks]
-install_deps = { depends_on = [
-    "install_OpenFBX",
-    "remove_deps_dir",
-] }
 lint = { cmd = "clang-format-18 -i axel/**/*.h axel/**/*.cpp momentum/**/*.h momentum/**/*.cpp pymomentum/**/*.h pymomentum/**/*.cpp" }
 build = { cmd = "cmake --build build -j --target all", depends_on = [
     "configure",
 ] }
-build_pymomentum = { cmd = "pip install -e .", depends_on = ["install_deps"] }
+build_pymomentum = { cmd = "pip install -e ." }
 
 #=========
 # win-64
@@ -123,14 +102,7 @@ build_pymomentum = { cmd = "pip install -e .", depends_on = ["install_deps"] }
 pytorch-cuda = ">=12.1,<13"
 
 [target.win-64.tasks]
-install_OpenFBX = { cmd = "git clone https://github.com/nem0/OpenFBX.git && cd OpenFBX && git checkout 932dbba1fe38b821d4de9b9ba64070e00e65549f && cd .. && cmake OpenFBX -B OpenFBX/build -G 'Visual Studio 17 2022' -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DOFBX_DOUBLE_PRECISION=ON && cmake --build OpenFBX/build --target install --config Release --parallel && rm -rf OpenFBX", cwd = ".deps", depends_on = [
-    "create_deps_dir",
-], outputs = [
-    "$CONDA_PREFIX/share/openfbx/openfbxConfig.cmake",
-] }
-configure = { cmd = "cmake -S . -B build -G 'Visual Studio 17 2022' -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_SHARED_LIBS=OFF -DMOMENTUM_BUILD_IO_FBX=ON -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON -DMOMENTUM_BUILD_TESTING=ON -DMOMENTUM_BUILD_EXAMPLES=ON -DMOMENTUM_BUILD_PYMOMENTUM=OFF", depends_on = [
-    "install_deps",
-], inputs = [
+configure = { cmd = "cmake -S . -B build -G 'Visual Studio 17 2022' -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_SHARED_LIBS=OFF -DMOMENTUM_BUILD_IO_FBX=ON -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON -DMOMENTUM_BUILD_TESTING=ON -DMOMENTUM_BUILD_EXAMPLES=ON -DMOMENTUM_BUILD_PYMOMENTUM=OFF", inputs = [
     "CMakeLists.txt",
 ] }
 open_vs = { cmd = "cmd /c start build\\momentum.sln", depends_on = [


### PR DESCRIPTION
Summary:
The OpenFBX package of Pixi was added by

- https://github.com/conda-forge/staged-recipes/pull/26738

Now that OpenFBX was the last dependency built from source for Momentum, all dependencies are now from Pixi, resulting in a much faster build process!

Differential Revision: D58916287


