### PR TITLE
Make glb_viewer support viewing glb file with only marker data

### DIFF
--- a/momentum/gui/rerun/logger.cpp
+++ b/momentum/gui/rerun/logger.cpp
@@ -159,6 +159,10 @@ void logMarkerLocatorCorrespondence(
     const LocatorState& locatorState,
     gsl::span<const Marker> markers,
     const float kPositionErrorThreshold) {
+  if (locatorLookup.empty()) {
+    // No correspondence provided.
+    return;
+  }
   std::vector<std::string> labels;
   std::vector<std::vector<std::array<float, 3>>> lines;
   std::vector<rerun::components::Color> colors;


### PR DESCRIPTION
Summary:
## Context
Previously, glb_viewer can't open a file that only contains marker data. 

## Changes
- Check the number of marker frames when getting the first frame and last frame, so the processing loop includes the full range. 
- Add a check for logging marker locator correspondence to avoid looping through all frames if the character is empty.

Reviewed By: jeongseok-meta

Differential Revision: D60696349


