### PR TITLE
Add link to C++ API doc to readme for visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ Momentum uses the `build/` directory for CMake builds, `.pixi/` for the Pixi vir
 
 ## 📖 Documentation
 
-The full documentation for Momentum can be found on our [website][docs].
+The full documentation for Momentum can be found on our [website][docs] and the C++ API documentation is available [here][cpp_api_doc].
 
 [docs]: https://facebookincubator.github.io/momentum
+[cpp_api_doc]: https://facebookincubator.github.io/momentum/doxygen/index.html
 
 ## Contributing
 

--- a/momentum/website/docusaurus.config.js
+++ b/momentum/website/docusaurus.config.js
@@ -74,7 +74,7 @@ const {fbContent, fbInternalOnly} = require('docusaurus-plugin-internaldocs-fb/i
           {
             href: 'pathname:///doxygen/index.html',
             position: 'left',
-            label: 'API',
+            label: 'C++ API',
           },
           {
             href: 'https://github.com/facebookincubator/momentum',


### PR DESCRIPTION
Summary: and rename `API` to `C++ API` for the link on the website for clarity

Differential Revision: D61302458


