### PR TITLE
Use config over module for finding boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,7 +451,7 @@ mt_library(
 #===============================================================================
 
 if(MOMENTUM_BUILD_TESTING)
-  find_package(Boost REQUIRED)
+  find_package(Boost CONFIG REQUIRED)
 
   enable_testing()
   mt_setup_gtest()


### PR DESCRIPTION
Summary:
Use the Boost configuration provided by upstream instead of the FindBoost module provided by CMake to address build warnings:

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1021949&view=logs&j=517fe804-fa30-5dc2-1413-330699242c05&t=c7d0fcb4-3a10-5b26-dfea-e879a93fc2ab&l=4260

```
  CMake Warning (dev) at CMakeLists.txt:454 (find_package):
    Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
    --help-policy CMP0167" for policy details.  Use the cmake_policy command to
    set the policy and suppress this warning.
```

Differential Revision: D62405205


