### PR TITLE
Update versions of pybind11 and gtest to the latest

### DIFF
--- a/cmake/mt_defs.cmake
+++ b/cmake/mt_defs.cmake
@@ -228,7 +228,7 @@ function(mt_setup_gtest)
   )
 
   if(NOT _ARG_GIT_TAG)
-    set(_ARG_GIT_TAG v1.14.0)
+    set(_ARG_GIT_TAG v1.15.2)
   endif()
 
   include(FetchContent)

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -25,7 +25,7 @@ include(FetchContent)
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11.git
-  GIT_TAG v2.12.0
+  GIT_TAG v2.13.5
 )
 set(PYBIND11_TEST OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(pybind11)


### PR DESCRIPTION
## Summary

Update versions of pybind11 and gtest to the latest

## Test Plan

GitHub CI

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`
