### PR TITLE
Fix incorrect member variable

### DIFF
--- a/momentum/character_solver/vertex_error_function.h
+++ b/momentum/character_solver/vertex_error_function.h
@@ -26,7 +26,7 @@ struct VertexConstraintT {
   VertexConstraintT<T2> cast() const {
     return {
         this->vertexIndex,
-        (T)this->weight_,
+        (T)this->weight,
         this->targetPosition.template cast<T2>(),
         this->targetNormal.template cast<T2>()};
   }


### PR DESCRIPTION
Summary: This variable doesn't exist. It's supposed to be `weight`. This was flagged when building with llvm-19

Reviewed By: yozhu

Differential Revision: D62666886


