### PR TITLE
Print build information in CMake configuration stage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,29 @@ project(momentum)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
+# Print intro
+message(STATUS "")
+message(STATUS "============================================")
+message(STATUS "                Momentum")
+message(STATUS "============================================")
+message(STATUS "")
+
+# Print OS and architecture information
+message(STATUS "[ System Info ]")
+message(STATUS "- Operating System    : ${CMAKE_SYSTEM_NAME}")
+message(STATUS "- Processor Arch      : ${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "")
+
+# Print build tool information
+message(STATUS "[ Build Tools ]")
+message(STATUS "- CMake               : ${CMAKE_VERSION}")
+message(STATUS "- C Compiler          : ${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}")
+message(STATUS "- C++ Compiler        : ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+if(MSVC)
+  message(STATUS "- CMake Toolchain File: ${CMAKE_TOOLCHAIN_FILE}")
+endif()
+message(STATUS "")
+
 #===============================================================================
 # Build dependencies
 #===============================================================================


### PR DESCRIPTION
## Summary

Print build information in CMake configuration stage, which is useful for debugging the builds

## Test Plan

```
pixi run configure
```

```
-- ============================================
--                 Momentum
-- ============================================
-- 
-- [ System Info ]
-- - Operating System    : Darwin
-- - Processor Arch      : arm64
-- 
-- [ Build Tools ]
-- - CMake               : 3.27.6
-- - C Compiler          : Clang 16.0.6
-- - C++ Compiler        : Clang 16.0.6
```

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`
