### PR TITLE
Print options for CMake configure output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,15 +50,17 @@ include(cmake/mt_defs.cmake)
 # Build Options
 #===============================================================================
 
-option(BUILD_SHARED_LIBS "Build as shared libraries" ON)
-option(MOMENTUM_ENABLE_SIMD "Enable building with SIMD instructions" ON)
-option(MOMENTUM_BUILD_IO_FBX "Build with IO FBX" OFF)
-option(MOMENTUM_BUILD_PYMOMENTUM "Build Python binding" OFF)
-option(MOMENTUM_BUILD_TESTING "Enable building tests" OFF)
-option(MOMENTUM_BUILD_EXAMPLES "Enable building examples" OFF)
-option(MOMENTUM_USE_SYSTEM_GOOGLETEST "Use GoogleTest installed in system" OFF)
-option(MOMENTUM_USE_SYSTEM_PYBIND11 "Use pybind11 installed in system" OFF)
-option(MOMENTUM_USE_SYSTEM_RERUN_CPP_SDK "Use Rerun C++ SDK installed in system" OFF)
+mt_option(BUILD_SHARED_LIBS "Build as shared libraries" ON)
+mt_option(MOMENTUM_ENABLE_SIMD "Enable building with SIMD instructions" ON)
+mt_option(MOMENTUM_BUILD_IO_FBX "Build with IO FBX" OFF)
+mt_option(MOMENTUM_BUILD_PYMOMENTUM "Build Python binding" OFF)
+mt_option(MOMENTUM_BUILD_TESTING "Enable building tests" OFF)
+mt_option(MOMENTUM_BUILD_EXAMPLES "Enable building examples" OFF)
+mt_option(MOMENTUM_USE_SYSTEM_GOOGLETEST "Use GoogleTest installed in system" OFF)
+mt_option(MOMENTUM_USE_SYSTEM_PYBIND11 "Use pybind11 installed in system" OFF)
+mt_option(MOMENTUM_USE_SYSTEM_RERUN_CPP_SDK "Use Rerun C++ SDK installed in system" OFF)
+
+mt_print_options()
 
 #===============================================================================
 # Find dependencies

--- a/cmake/mt_defs.cmake
+++ b/cmake/mt_defs.cmake
@@ -50,6 +50,98 @@ function(mt_append_pymomentum_filelist name outputvar)
   set(${outputvar} "${${outputvar}}" PARENT_SCOPE)
 endfunction()
 
+# mt_get_max(var [value1 value2...])
+function(mt_get_max var)
+  set(first YES)
+  set(choice NO)
+  foreach(item ${ARGN})
+    if(first)
+      set(choice ${item})
+      set(first NO)
+    elseif(choice LESS ${item})
+      set(choice ${item})
+    endif()
+  endforeach(item)
+  set(${var} ${choice} PARENT_SCOPE)
+endfunction()
+
+# mt_get_max_string_length(var [value1 value2...])
+function(mt_get_max_string_length var)
+  foreach(item ${ARGN})
+    string(LENGTH ${item} length)
+    list(APPEND list ${length})
+  endforeach()
+  mt_get_max(choice ${list})
+  set(${var} ${choice} PARENT_SCOPE)
+endfunction()
+
+# mt_option(<variable> "<help_text>" <value>)
+function(mt_option variable help_text default_value)
+  set_property(
+    GLOBAL PROPERTY MOMENTUM_DETAIL_PROPERTY_OPTION_VARIABLE "${variable}" APPEND
+  )
+  set_property(
+    GLOBAL PROPERTY MOMENTUM_DETAIL_property_option_help_text "${help_text}" APPEND
+  )
+  set_property(
+    GLOBAL PROPERTY MOMENTUM_DETAIL_property_option_default_value "${default_value}"
+    APPEND
+  )
+
+  # Add option
+  option(${variable} ${help_text} ${default_value})
+
+  # Normalize boolean value variants (e.g. 1/0, On/Off, TRUE/FALSE) to ON/OFF
+  if(${variable})
+    set(${variable} ON PARENT_SCOPE)
+  else()
+    set(${variable} OFF PARENT_SCOPE)
+  endif()
+
+endfunction()
+
+function(mt_print_options)
+  # Print the header
+  message(STATUS "[ Options ]")
+
+  get_property(
+    option_variables GLOBAL PROPERTY MOMENTUM_DETAIL_PROPERTY_OPTION_VARIABLE
+  )
+  get_property(
+    option_help_texts GLOBAL PROPERTY MOMENTUM_DETAIL_property_option_help_text
+  )
+  get_property(
+    option_default_values GLOBAL
+    PROPERTY MOMENTUM_DETAIL_property_option_default_value
+  )
+
+  mt_get_max_string_length(option_variable_max_len ${option_variables})
+  list(LENGTH option_variables option_count)
+  math(EXPR option_count "${option_count} - 1")
+  foreach(val RANGE ${option_count})
+    list(GET option_variables ${val} option_variable)
+    list(GET option_default_values ${val} option_default_value)
+
+    set(option_str "- ${option_variable}")
+    set(spaces "")
+    string(LENGTH ${option_variable} option_variable_len)
+    math(EXPR space_count "${option_variable_max_len} - ${option_variable_len}")
+    foreach(loop_var RANGE ${space_count})
+      set(option_str "${option_str} ")
+    endforeach()
+
+    set(option_str "${option_str}: ${${option_variable}}")
+
+    if(${option_variable} STREQUAL option_default_value)
+      set(option_str "${option_str} [default]")
+    endif()
+
+    message(STATUS "${option_str}")
+  endforeach()
+
+  message(STATUS "")
+endfunction()
+
 function(mt_library)
   set(prefix _ARG)
   set(options


### PR DESCRIPTION
## Summary

Print options for CMake configure output for easier debugging in build logs

## Test Plan

```
pixi run configure
```

Before:

```
-- ============================================
--                 Momentum
-- ============================================
-- 
-- [ System Info ]
-- - Operating System    : Darwin
-- - Processor Arch      : arm64
-- 
-- [ Build Tools ]
-- - CMake               : 3.27.6
-- - C Compiler          : Clang 16.0.6
-- - C++ Compiler        : Clang 16.0.6
```

After:

```
-- ============================================
--                 Momentum
-- ============================================
-- 
-- [ System Info ]
-- - Operating System    : Darwin
-- - Processor Arch      : arm64
-- 
-- [ Build Tools ]
-- - CMake               : 3.27.6
-- - C Compiler          : Clang 16.0.6
-- - C++ Compiler        : Clang 16.0.6
-- 
-- [ Options ]
-- - BUILD_SHARED_LIBS                 : ON [default]
-- - MOMENTUM_ENABLE_SIMD              : ON [default]
-- - MOMENTUM_BUILD_IO_FBX             : OFF [default]
-- - MOMENTUM_BUILD_PYMOMENTUM         : ON
-- - MOMENTUM_BUILD_TESTING            : ON
-- - MOMENTUM_BUILD_EXAMPLES           : ON
-- - MOMENTUM_USE_SYSTEM_GOOGLETEST    : ON
-- - MOMENTUM_USE_SYSTEM_PYBIND11      : ON
-- - MOMENTUM_USE_SYSTEM_RERUN_CPP_SDK : ON
```

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`
