### PR TITLE
Remove unnecessary conda channels from pixi.toml

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -2,15 +2,13 @@ version: 5
 environments:
   default:
     channels:
-    - url: https://conda.anaconda.org/nvidia/
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.anaconda.org/pytorch/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-64_curr_repodata_hack-3-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anywidget-0.9.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
@@ -29,46 +27,46 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.267-hddb5a97_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-ha1999f0_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hb3c18ed_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-2.123-openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-23_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/boost-1.84.0-h9cebb41_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hb3c18ed_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-2.124-openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-24_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/boost-1.84.0-h9cebb41_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.33.1-heb4867d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.7.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ceres-solver-2.2.0-ha77e7a2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-18-18.1.8-default_hf981a13_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-18-18.1.8-default_hf981a13_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cli11-2.4.1-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.27.6-hcfe8598_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.29.3-h91dbaaa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.7.0-h00ab1b0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/dispenso-1.3.0-h5888daf_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dispenso-1.3.0-h5888daf_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/drjit-cpp-0.4.6-h5888daf_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ezc3d-1.5.9-py312_python3_h0990d18_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-10.2.1-h00ab1b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fx-gltf-2.0.0-h5888daf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.4.0-h236703b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.4.0-hb2e57f8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.4.0-h6b7512a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.4.0-h6b7512a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.1.5-py312h1d5cde6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.1.5-py312h7201bc8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.15.2-h434a139_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.4.0-h236703b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.4.0-h613a52c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.4.0-h8489865_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.4.0-h8489865_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.27.0-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.5-pyhd8ed1ab_0.conda
@@ -90,24 +88,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-15.0.2-he4f5ca8_6_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-15.0.2-hc1954e9_6_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-15.0.2-he4f5ca8_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-23_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.84.0-h0ccab89_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.84.0-h00ab1b0_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.84.0-ha770c72_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.84.0-py312hf74af30_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-devel-1.84.0-py312h9cebb41_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-23_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp18.1-18.1.8-default_hf981a13_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-24_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.84.0-hb8260a3_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.84.0-h1a2810e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.84.0-ha770c72_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.84.0-py312hc39e661_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-devel-1.84.0-py312h9cebb41_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-24_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp18.1-18.1.8-default_hf981a13_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.7.1-hca28451_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.21-h4bc722e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.1.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-12.4.0-ha4f9413_101.conda
@@ -122,8 +120,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.1-default_hecaa2ac_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-23_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-23_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-24_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-24_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm16-16.0.6-hb3ce162_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm18-18.1.8-h8b73ec9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
@@ -131,18 +129,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_hac2b453_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-15.0.2-hacf5a1f_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librerun-sdk-0.18.2-hfa1e435_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.4.0-h46f95d5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.1.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-12.4.0-ha4f9413_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-h4852527_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h46a8edc_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-h6565414_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.4.0-cpu_mkl_h85b1651_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
@@ -158,8 +156,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-h59595ed_1007.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2023.2.0-h84fe81f_50496.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.3.1-h24ddda3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h38ae2d0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.3.1-h24ddda3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h90cbb55_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ms-gsl-4.0.0-h434a139_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
@@ -170,23 +168,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openblas-0.3.27-pthreads_h9eca1d5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openfbx-0.9-hb9b21f8_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.2-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.0-h17fec99_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py312h287a98d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py312h56024de_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyh8b19718_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psygnal-0.11.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-15.0.2-py312h3f82784_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pybind11-2.13.5-py312h68727a3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pybind11-global-2.13.5-py312h68727a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pybind11-2.13.6-py312h68727a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pybind11-global-2.13.6-py312h68727a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.3-hab00c5b_0_cpython.conda
@@ -201,7 +199,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.13.1-py312hc2bc53b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.6.1-h1b44611_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.7-h1b44611_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.12.0-hd2e6256_2.conda
@@ -209,24 +207,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/suitesparse-7.8.2-hb42a789_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.2-pypyh2585a3b_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-he073ed8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.12.0-h84d6215_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-ha691c75_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-0.24.0-py312h12e396e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-0.24.0-py312h12e396e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py312h66e93f0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
       osx-64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anywidget-0.9.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
@@ -243,50 +241,51 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-h53e3db5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.8-ha933895_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.267-h8dd24e3_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/blas-2.122-openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/blas-devel-3.9.0-22_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/boost-1.84.0-h0be7463_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blas-2.124-blis.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blas-devel-3.9.0-24_osx64_blis.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blis-0.9.0-hec52a4b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/boost-1.84.0-h0be7463_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.33.1-h44e7173_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.7.0-h282daa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-986-h40f6528_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-986-h303a5ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-1010.6-h40f6528_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1010.6-heaa7f0c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ceres-solver-2.2.0-h337fa08_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h0c94c6a_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-default_h179603d_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-format-18-18.1.8-default_h0c94c6a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-format-18-18.1.8-default_h0c94c6a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h179603d_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cli11-2.4.1-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.27.6-hf40c264_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.29.3-h1304840_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-16.0.6-ha38d28d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.7.0-h7728843_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/dispenso-1.3.0-hac325c4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/dispenso-1.3.0-hac325c4_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/drjit-cpp-0.4.6-hac325c4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ezc3d-1.5.9-py312_python3_h688da4f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-10.2.1-h7728843_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fx-gltf-2.0.0-hac325c4_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gmpy2-2.1.5-py312hd98c385_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gmpy2-2.1.5-py312h165121d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gtest-1.15.2-h3c5361c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.27.0-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.5-pyhd8ed1ab_0.conda
@@ -296,8 +295,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-711-ha02d983_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-711-h04ffbf3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-951.9-ha02d983_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-951.9-h3516399_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.2-cxx17_hf036a51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-15.0.2-hfba3c4c_6_cpu.conda
@@ -307,27 +306,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-15.0.2-hb2e0ddf_6_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-15.0.2-h81ca85a_6_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-15.0.2-hb2e0ddf_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-22_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.84.0-hcca3243_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-devel-1.84.0-h2b186f8_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.84.0-h694c41f_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-python-1.84.0-py312h44e70fa_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-python-devel-1.84.0-py312h0be7463_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-22_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-24_osx64_blis.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.84.0-hbe88bda_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-devel-1.84.0-h6a1c779_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.84.0-h694c41f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-python-1.84.0-py312h082b758_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-python-devel-1.84.0-py312h0be7463_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-24_osx64_blis.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h0c94c6a_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp18.1-18.1.8-default_h0c94c6a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp18.1-18.1.8-default_h0c94c6a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.7.1-h726d00d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-hd876a4e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.0-hf95d169_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-devel-16.0.6-h8f8a49f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.21-hfdf4475_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.3-hac325c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
@@ -337,21 +336,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.11.1-default_h456cccd_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-22_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-22_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-7_ha55dbfc_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-7_ha55dbfc_netlib.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm16-16.0.6-hbedff68_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm18-18.1.8-h9ce406d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_h8869122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-15.0.2-h7cd3cfe_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.09.01-h81f5012_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/librerun-sdk-0.18.2-h659d0a5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.1-h4b8f8c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h603087a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h5f227bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libtorch-2.4.0-cpu_mkl_h3542c91_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.48.0-h67532ce_0.conda
@@ -366,8 +364,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/metis-5.1.0-he965462_1007.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mkl-2023.2.0-h54c2260_50500.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h9d8efa1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.2.1-hc80595b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h9d8efa1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.2.1-haed47dc_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ms-gsl-4.0.0-h3c5361c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
@@ -375,26 +373,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nlohmann_json-3.11.3-hf036a51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openblas-0.3.27-openmp_hba01982_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openfbx-0.9-h244a513_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.2-h87427d6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.3-hd23fc13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.0-hf146577_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.4.0-py312hbd70edc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.4.0-py312h683ea77_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyh8b19718_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psygnal-0.11.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-15.0.2-py312h3db2695_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pybind11-2.13.5-py312hc5c4d5f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pybind11-global-2.13.5-py312hc5c4d5f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pybind11-2.13.6-py312hc5c4d5f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pybind11-global-2.13.6-py312hc5c4d5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.3-h1411813_0_cpython.conda
@@ -408,31 +405,31 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/sleef-3.6.1-h01aa1be_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sleef-3.7-h01aa1be_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.12.0-h8dd852c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/suitesparse-7.8.2-ha93ada7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.2-pypyh2585a3b_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.12.0-h37c8870_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.13.0-h37c8870_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/watchfiles-0.24.0-py312h669792a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/watchfiles-0.24.0-py312h669792a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py312hb553811_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
       osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anywidget-0.9.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
@@ -449,50 +446,50 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.18-hd34e5fa_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.26.8-h7541583_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.267-h18943f6_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-2.123-openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-devel-3.9.0-23_osxarm64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/boost-1.84.0-ha814d7c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-2.124-openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-devel-3.9.0-24_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/boost-1.84.0-ha814d7c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.33.1-hd74edd7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.7.0-h6aa9301_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-986-h4faf515_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-986-h670d6a2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1010.6-h4faf515_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1010.6-h4f2c9d0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ceres-solver-2.2.0-h4929e67_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_h5c12605_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-default_h675cc0c_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-18-18.1.8-default_h5c12605_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-18-18.1.8-default_h5c12605_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h675cc0c_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cli11-2.4.1-hebf3989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.27.6-h1c59155_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.29.3-h2cf84f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-16.0.6-h3808999_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.7.0-h2ffa867_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dispenso-1.3.0-hf9b8971_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dispenso-1.3.0-hf9b8971_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/drjit-cpp-0.4.6-hf9b8971_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ezc3d-1.5.9-py312_python3_h0e7aeb7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-10.2.1-h2ffa867_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fx-gltf-2.0.0-hf9b8971_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.1.5-py312hfa9fade_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.1.5-py312h87fada9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtest-1.15.2-h420ef59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.27.0-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.5-pyhd8ed1ab_0.conda
@@ -502,8 +499,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-711-h634c8be_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-711-h4c89ff5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-951.9-h634c8be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-951.9-h0605c9f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.2-cxx17_h00cdb27_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-15.0.2-hea125af_6_cpu.conda
@@ -513,27 +510,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-15.0.2-hb630850_6_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-15.0.2-h3b9069c_6_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-15.0.2-hd92e347_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-23_osxarm64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.84.0-hf763ba5_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-devel-1.84.0-hf450f58_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-headers-1.84.0-hce30654_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-python-1.84.0-py312hffe1f2a_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-python-devel-1.84.0-py312ha814d7c_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-23_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-24_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.84.0-h29978a0_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-devel-1.84.0-hf450f58_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-headers-1.84.0-hce30654_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-python-1.84.0-py312h707656b_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-python-devel-1.84.0-py312ha814d7c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-24_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_h5c12605_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp18.1-18.1.8-default_h5c12605_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp18.1-18.1.8-default_h5c12605_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.7.1-h2d989ff_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-18.1.8-h3ed4263_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.0-ha82da77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-devel-16.0.6-h86353a2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.21-h99b78c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
@@ -543,21 +540,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.11.1-default_h7685b71_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-23_osxarm64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-23_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-24_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-24_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm16-16.0.6-haab561b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm18-18.1.8-h5090b49_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.27-openmp_h517c56d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-15.0.2-h5304c63_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hbfab5d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.09.01-h7b2c953_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librerun-sdk-0.18.2-h63ed062_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.1-hc14010f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-hf8409c0_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-h9c1d414_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtorch-2.4.0-cpu_generic_h4365fe2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.48.0-h93a5062_0.conda
@@ -571,8 +568,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.5-py312h024a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h13dd4ca_1007.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-h1cfca0a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ms-gsl-4.0.0-h420ef59_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
@@ -584,23 +581,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openblas-0.3.27-openmp_h560b219_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openfbx-0.9-h07e6450_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.2-hfb2fe0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.3-h8359307_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.0-h4aad248_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.4.0-py312h39b1d8d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.4.0-py312h8609ca0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyh8b19718_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psygnal-0.11.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-15.0.2-py312hbf1f86f_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-2.13.5-py312h6142ec9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-global-2.13.5-py312h6142ec9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-2.13.6-py312h6142ec9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-global-2.13.6-py312h6142ec9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.3-h4a7b5fc_0_cpython.conda
@@ -614,31 +611,31 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.6.1-h7783ee8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.7-h7783ee8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.12.0-he64bfa9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/suitesparse-7.8.2-hec630bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.2-pypyh2585a3b_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.12.0-h7b3277c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.13.0-h7b3277c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-0.24.0-py312he431725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-0.24.0-py312he431725_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py312h024a12e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
       win-64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anywidget-0.9.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
@@ -657,46 +654,31 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.267-h12f3f85_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/blas-2.123-mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/blas-devel-3.9.0-23_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/boost-1.84.0-h7e22eef_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/boost-1.84.0-h7e22eef_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.33.1-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.7.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ceres-solver-2.2.0-h176f1a4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cli11-2.4.1-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.27.6-hf0feee3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.30.1-h400e5d1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cccl-12.6.37-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cccl_win-64-12.6.37-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-dev-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cupti-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-12.4.0-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-dev-12.4.0-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-dev-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvtx-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-opencl-12.6.68-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-opencl-dev-12.6.68-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-profiler-api-12.6.68-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-runtime-12.4.0-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-version-12.6-3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.7.0-h91493d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/dispenso-1.3.0-he0c23c2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dispenso-1.3.0-he0c23c2_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/drjit-cpp-0.4.6-he0c23c2_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ezc3d-1.5.9-py312_python3_hcb2535b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-10.2.1-h181d51b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fx-gltf-2.0.0-he0c23c2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gflags-2.2.2-ha925a31_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gflags-2.2.2-he0c23c2_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glog-0.7.1-h3ff59bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gtest-1.15.2-hc790b64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.27.0-pyh7428d3b_0.conda
@@ -716,30 +698,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-15.0.2-hd4515a1_6_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-15.0.2-h1f0e801_6_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-23_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.84.0-h444863b_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-devel-1.84.0-h91493d7_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.84.0-h57928b3_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-python-1.84.0-py312hbaa7e33_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-python-devel-1.84.0-py312h7e22eef_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.84.0-h444863b_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-devel-1.84.0-h91493d7_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.84.0-h57928b3_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-python-1.84.0-py312hbaa7e33_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-python-devel-1.84.0-py312h7e22eef_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-23_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcublas-12.4.2.65-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcublas-dev-12.4.2.65-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcufft-11.2.0.44-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcufft-dev-11.2.0.44-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcurand-10.3.7.68-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcurand-dev-10.3.7.68-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.8.0-hd5e4a3a_0.conda
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcusolver-11.6.0.99-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcusolver-dev-11.6.0.99-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcusparse-12.3.0.142-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcusparse-dev-12.3.0.142-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.21-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.3-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.23.0-h68df31e_1.conda
@@ -750,23 +722,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-23_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-23_win64_mkl.conda
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnpp-12.2.5.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnpp-dev-12.2.5.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnvfatbin-12.6.68-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnvfatbin-dev-12.6.68-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnvjitlink-12.4.99-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnvjitlink-dev-12.4.99-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-12.3.1.89-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-dev-12.3.1.89-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-15.0.2-h178134c_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.09.01-hf8d8778_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/librerun-sdk-0.18.2-ha4e701c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.1-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hb151862_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hb151862_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.48.0-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
@@ -793,12 +757,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/openfbx-0.9-h2fe44f6_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.2-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.3-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.0-h7e885a9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py312h381445a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py312h381445a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyh8b19718_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
@@ -807,13 +771,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-15.0.2-py312h4af9903_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pybind11-2.13.5-py312hd5eb7cc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pybind11-global-2.13.5-py312hd5eb7cc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pybind11-2.13.6-py312hd5eb7cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pybind11-global-2.13.6-py312hd5eb7cc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
-      - conda: https://conda.anaconda.org/pytorch/win-64/pytorch-cuda-12.4-h3fd98bf_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.09.01-hd3b24a8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rerun-sdk-0.18.2-py312h88e7180_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.13.1-py312h1f4e10d_0.conda
@@ -824,19 +787,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.12.0-h64d2f7d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/suitesparse-7.8.2-h7e725d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_21.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/watchfiles-0.24.0-py312h2615798_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/watchfiles-0.24.0-py312h2615798_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_0.conda
@@ -889,26 +852,27 @@ packages:
   timestamp: 1720621358501
 - kind: conda
   name: anyio
-  version: 4.4.0
-  build: pyhd8ed1ab_0
+  version: 4.6.0
+  build: pyhd8ed1ab_1
+  build_number: 1
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
-  sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
-  md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.0-pyhd8ed1ab_1.conda
+  sha256: d05493abca6ac1b0cb15f5d48c3117bddd73cc21e48bfcb460570cfa2ea2f909
+  md5: bc13891a047f50728b03595531f7f92e
   depends:
   - exceptiongroup >=1.0.2
   - idna >=2.8
-  - python >=3.8
+  - python >=3.9
   - sniffio >=1.1
   - typing_extensions >=4.1
   constrains:
-  - uvloop >=0.17
-  - trio >=0.23
+  - uvloop >=0.21.0b1
+  - trio >=0.26.1
   license: MIT
   license_family: MIT
-  size: 104255
-  timestamp: 1717693144467
+  size: 108445
+  timestamp: 1726931347728
 - kind: conda
   name: anywidget
   version: 0.9.13
@@ -1949,41 +1913,19 @@ packages:
 - kind: conda
   name: binutils_linux-64
   version: '2.40'
-  build: hb3c18ed_1
-  build_number: 1
+  build: hb3c18ed_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hb3c18ed_1.conda
-  sha256: fc7123b9b3fe79e66b5196500ce6d555ad7ebcdf15b0cf86b728ef52f144ee65
-  md5: 36644b44330c28c797e9fd2c88bcd73e
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hb3c18ed_3.conda
+  sha256: 5bc2f56de9144c857980baff9815fdd258e163aab3864babea523bed3eebd016
+  md5: 0b71bae00509f31931ebb407626352aa
   depends:
   - binutils_impl_linux-64 2.40.*
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
-  size: 29235
-  timestamp: 1724909758636
-- kind: conda
-  name: blas
-  version: '2.122'
-  build: openblas
-  build_number: 22
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/blas-2.122-openblas.conda
-  sha256: 8abf0147de2535295aac5024601e8a0480ae29ca65ee745a70fbec42c792623a
-  md5: 257c7913153f848394cf1679a04c60a8
-  depends:
-  - blas-devel 3.9.0 22_osx64_openblas
-  - libblas 3.9.0 22_osx64_openblas
-  - libcblas 3.9.0 22_osx64_openblas
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - libgfortran5 >=13.2.0
-  - liblapack 3.9.0 22_osx64_openblas
-  - liblapacke 3.9.0 22_osx64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14767
-  timestamp: 1712542625406
+  size: 29049
+  timestamp: 1717992426736
 - kind: conda
   name: blas
   version: '2.123'
@@ -2007,110 +1949,74 @@ packages:
   timestamp: 1721689864771
 - kind: conda
   name: blas
-  version: '2.123'
+  version: '2.124'
+  build: blis
+  build_number: 24
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/blas-2.124-blis.conda
+  sha256: c8e1a9aa18781d0d0f188ffb80b69741dd983f5af2f625829bc1728eefefd8c0
+  md5: f4872e9958a71c2202e67f69c89c8d3b
+  depends:
+  - __osx >=10.13
+  - blas-devel 3.9.0 24_osx64_blis
+  - libblas 3.9.0 24_osx64_blis
+  - libcblas 3.9.0 24_osx64_blis
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - liblapack 3.9.0 *netlib
+  - liblapacke 3.9.0 *netlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2949619
+  timestamp: 1726668691432
+- kind: conda
+  name: blas
+  version: '2.124'
   build: openblas
-  build_number: 23
+  build_number: 24
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/blas-2.123-openblas.conda
-  sha256: e50913fe846d5d6e6f5a3553d5e6776bfd07b2530b30095669b8499c0ff35094
-  md5: 7f4b3ea1cdd6e50dca2a226abda6e2d9
+  url: https://conda.anaconda.org/conda-forge/linux-64/blas-2.124-openblas.conda
+  sha256: c6821ab3082141de3cd8714d5377f74e7309e63bf535493c8de433ed6a95fb35
+  md5: fec523f5e113812b956ec1adaec1212e
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex * *_llvm
   - _openmp_mutex >=4.5
-  - blas-devel 3.9.0 23_linux64_openblas
-  - libblas 3.9.0 23_linux64_openblas
-  - libcblas 3.9.0 23_linux64_openblas
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.4.0
-  - liblapack 3.9.0 23_linux64_openblas
-  - liblapacke 3.9.0 23_linux64_openblas
+  - blas-devel 3.9.0 24_linux64_openblas
+  - libblas 3.9.0 24_linux64_openblas
+  - libcblas 3.9.0 24_linux64_openblas
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack 3.9.0 24_linux64_openblas
+  - liblapacke 3.9.0 24_linux64_openblas
   - llvm-openmp >=18.1.8
   license: BSD-3-Clause
   license_family: BSD
-  size: 15026
-  timestamp: 1721688858035
+  size: 15102
+  timestamp: 1726668549758
 - kind: conda
   name: blas
-  version: '2.123'
+  version: '2.124'
   build: openblas
-  build_number: 23
+  build_number: 24
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/blas-2.123-openblas.conda
-  sha256: 77ec7afd6d47785917982c997b4118982f750988fc12121263057d7ba4929837
-  md5: a059a9d9b485affbe7b7bac8c9f15df3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/blas-2.124-openblas.conda
+  sha256: 2e47f33a41ee27adeb77e171bbb67d2714ab90d84bef96c63afc1d073fb70aa1
+  md5: fd72eb50d62dfa061f0ef9df0da95faa
   depends:
   - __osx >=11.0
-  - blas-devel 3.9.0 23_osxarm64_openblas
-  - libblas 3.9.0 23_osxarm64_openblas
-  - libcblas 3.9.0 23_osxarm64_openblas
+  - blas-devel 3.9.0 24_osxarm64_openblas
+  - libblas 3.9.0 24_osxarm64_openblas
+  - libcblas 3.9.0 24_osxarm64_openblas
   - libgfortran 5.*
-  - libgfortran5 >=12.3.0
   - libgfortran5 >=13.2.0
-  - liblapack 3.9.0 23_osxarm64_openblas
-  - liblapacke 3.9.0 23_osxarm64_openblas
+  - liblapack 3.9.0 24_osxarm64_openblas
+  - liblapacke 3.9.0 24_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 15239
-  timestamp: 1721689061396
-- kind: conda
-  name: blas-devel
-  version: 3.9.0
-  build: 22_osx64_openblas
-  build_number: 22
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/blas-devel-3.9.0-22_osx64_openblas.conda
-  sha256: 26a7971f1e3355a0ba209791c0765c7f135b50d6d9dd620039e0ddb93b204e38
-  md5: 15c86fd5a560679946bab696f3540db0
-  depends:
-  - libblas 3.9.0 22_osx64_openblas
-  - libcblas 3.9.0 22_osx64_openblas
-  - liblapack 3.9.0 22_osx64_openblas
-  - liblapacke 3.9.0 22_osx64_openblas
-  - openblas 0.3.27.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14637
-  timestamp: 1712542346165
-- kind: conda
-  name: blas-devel
-  version: 3.9.0
-  build: 23_linux64_openblas
-  build_number: 23
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-23_linux64_openblas.conda
-  sha256: b84be53e83d5c18254bb9664ebe15dbf559898f78aecdb3cce9f3f121d2f8ee8
-  md5: 08b43a5c3d6cc13aeb69bd2cbc293196
-  depends:
-  - libblas 3.9.0 23_linux64_openblas
-  - libcblas 3.9.0 23_linux64_openblas
-  - liblapack 3.9.0 23_linux64_openblas
-  - liblapacke 3.9.0 23_linux64_openblas
-  - openblas 0.3.27.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14835
-  timestamp: 1721688790396
-- kind: conda
-  name: blas-devel
-  version: 3.9.0
-  build: 23_osxarm64_openblas
-  build_number: 23
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/blas-devel-3.9.0-23_osxarm64_openblas.conda
-  sha256: 3c3d3977c984334dff9ba63094db01b45e4f7fdd6a10f725f28817a5282267ef
-  md5: 3bf47db3b06424dd6d828c7d2f155d8f
-  depends:
-  - libblas 3.9.0 23_osxarm64_openblas
-  - libcblas 3.9.0 23_osxarm64_openblas
-  - liblapack 3.9.0 23_osxarm64_openblas
-  - liblapacke 3.9.0 23_osxarm64_openblas
-  - openblas 0.3.27.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 15015
-  timestamp: 1721689044079
+  size: 15289
+  timestamp: 1726668844414
 - kind: conda
   name: blas-devel
   version: 3.9.0
@@ -2132,69 +2038,140 @@ packages:
   size: 16869
   timestamp: 1721689735203
 - kind: conda
-  name: boost
-  version: 1.84.0
-  build: h0be7463_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/boost-1.84.0-h0be7463_5.conda
-  sha256: 5324a460e9445d91e2d0ca8e2c9e524c41580b17e0fc8a149969adb5a4a639d4
-  md5: 0fe8b63d0c08a288ae4f049705185aa1
-  depends:
-  - libboost-python-devel 1.84.0 py312h0be7463_5
-  - numpy >=1.19,<3
-  - python_abi 3.12.* *_cp312
-  license: BSL-1.0
-  size: 16990
-  timestamp: 1722291244458
-- kind: conda
-  name: boost
-  version: 1.84.0
-  build: h7e22eef_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/boost-1.84.0-h7e22eef_5.conda
-  sha256: 72a372fc13417e10507d238f885bd9022f84925ca8c6d704ceeaf2ab34f087a8
-  md5: 7291ade4d04c563f8ef3609dacb397a5
-  depends:
-  - libboost-python-devel 1.84.0 py312h7e22eef_5
-  - numpy >=1.19,<3
-  - python_abi 3.12.* *_cp312
-  license: BSL-1.0
-  size: 17505
-  timestamp: 1722293290389
-- kind: conda
-  name: boost
-  version: 1.84.0
-  build: h9cebb41_5
-  build_number: 5
+  name: blas-devel
+  version: 3.9.0
+  build: 24_linux64_openblas
+  build_number: 24
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/boost-1.84.0-h9cebb41_5.conda
-  sha256: 6b5e8862efa03e45a9f78ffbac1a486d5765cad559636cb39c553065d0237ba1
-  md5: 7797a3fc21f834d92a86cb4912be77f3
+  url: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-24_linux64_openblas.conda
+  sha256: 53cbbc08dab49901d578bcb782fe2aef0089b85654fd3850a9eb524e377e5eb8
+  md5: 4485873878da20ee1ce0f21d248b33d9
   depends:
-  - libboost-python-devel 1.84.0 py312h9cebb41_5
-  - numpy >=1.19,<3
-  - python_abi 3.12.* *_cp312
-  license: BSL-1.0
-  size: 16851
-  timestamp: 1722290617545
+  - libblas 3.9.0 24_linux64_openblas
+  - libcblas 3.9.0 24_linux64_openblas
+  - liblapack 3.9.0 24_linux64_openblas
+  - liblapacke 3.9.0 24_linux64_openblas
+  - openblas 0.3.27.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14885
+  timestamp: 1726668479589
+- kind: conda
+  name: blas-devel
+  version: 3.9.0
+  build: 24_osx64_blis
+  build_number: 24
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/blas-devel-3.9.0-24_osx64_blis.conda
+  sha256: 0c3408b6a348dbe972d4d88106bc6798a3d5fa02c8ee06d4bdcda0b8adb32f9a
+  md5: ae4e3f81453f0db630d3cd760e91499c
+  depends:
+  - libblas 3.9.0 24_osx64_blis
+  - libcblas 3.9.0 24_osx64_blis
+  - liblapack 3.9.0 *netlib
+  - liblapacke 3.9.0 *netlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14691
+  timestamp: 1726668637760
+- kind: conda
+  name: blas-devel
+  version: 3.9.0
+  build: 24_osxarm64_openblas
+  build_number: 24
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/blas-devel-3.9.0-24_osxarm64_openblas.conda
+  sha256: ad8389dd0c1c2964c6eff48740aa2bf8b5cc0714eba6b795cb89f9e24a77dd7f
+  md5: 7a7cd1810e2d4236b5bc642c8d85d5fe
+  depends:
+  - libblas 3.9.0 24_osxarm64_openblas
+  - libcblas 3.9.0 24_osxarm64_openblas
+  - liblapack 3.9.0 24_osxarm64_openblas
+  - liblapacke 3.9.0 24_osxarm64_openblas
+  - openblas 0.3.27.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15065
+  timestamp: 1726668829168
+- kind: conda
+  name: blis
+  version: 0.9.0
+  build: hec52a4b_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/blis-0.9.0-hec52a4b_2.conda
+  sha256: 709d70079d8b629cc6a9f96c52e818546ffe67fe97c7e09b2264611f19551934
+  md5: 2bbab6245067770bc4e9652a3e60de86
+  depends:
+  - __osx >=10.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1346304
+  timestamp: 1713878136186
 - kind: conda
   name: boost
   version: 1.84.0
-  build: ha814d7c_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/boost-1.84.0-ha814d7c_5.conda
-  sha256: 179476f9bb271d1fd1ba27d70b8629deabd3c893a113dd10bade5e3685d9f0f3
-  md5: d6b79cf1647310a4ebc161b687dd6c23
+  build: h0be7463_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/boost-1.84.0-h0be7463_6.conda
+  sha256: fc9c808833cdf293932c5a4da0b7e3f57b3e6790d643d2448d4490638bcee942
+  md5: 69363e6826364df4b8764110c527bcfb
   depends:
-  - libboost-python-devel 1.84.0 py312ha814d7c_5
+  - libboost-python-devel 1.84.0 py312h0be7463_6
   - numpy >=1.19,<3
   - python_abi 3.12.* *_cp312
   license: BSL-1.0
-  size: 17063
-  timestamp: 1722291614629
+  size: 17004
+  timestamp: 1725327172051
+- kind: conda
+  name: boost
+  version: 1.84.0
+  build: h7e22eef_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/boost-1.84.0-h7e22eef_6.conda
+  sha256: 9e7921e559ba7b05e89a3e0318fb22d763b34fa4e51cab10606c3634df961498
+  md5: 5b5e8d5d7b08bebe1f2f0ad9bb2441fa
+  depends:
+  - libboost-python-devel 1.84.0 py312h7e22eef_6
+  - numpy >=1.19,<3
+  - python_abi 3.12.* *_cp312
+  license: BSL-1.0
+  size: 17561
+  timestamp: 1725329178689
+- kind: conda
+  name: boost
+  version: 1.84.0
+  build: h9cebb41_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/boost-1.84.0-h9cebb41_6.conda
+  sha256: b21e3082117b0623669d1a2166e337f19794e422a2559e8c9d6519d96e94ca88
+  md5: 76838bf7691935db98e835bf96802a7c
+  depends:
+  - libboost-python-devel 1.84.0 py312h9cebb41_6
+  - numpy >=1.19,<3
+  - python_abi 3.12.* *_cp312
+  license: BSL-1.0
+  size: 16954
+  timestamp: 1725326556264
+- kind: conda
+  name: boost
+  version: 1.84.0
+  build: ha814d7c_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/boost-1.84.0-ha814d7c_6.conda
+  sha256: 093b9509ebd3dc75116f87a5bcce091fee461f0f36e008f431dfa1f6f1333976
+  md5: a44a5c39848ddbcf4f3ee3bfb069a70a
+  depends:
+  - libboost-python-devel 1.84.0 py312ha814d7c_6
+  - numpy >=1.19,<3
+  - python_abi 3.12.* *_cp312
+  license: BSL-1.0
+  size: 17084
+  timestamp: 1725327959480
 - kind: conda
   name: bzip2
   version: 1.0.8
@@ -2431,86 +2408,88 @@ packages:
   timestamp: 1725019034582
 - kind: conda
   name: cctools
-  version: '986'
-  build: h40f6528_3
-  build_number: 3
+  version: '1010.6'
+  build: h40f6528_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cctools-986-h40f6528_3.conda
-  sha256: f8a1cb618c8567e8539c92bd38719ecac0322dea4ef382bf14a95f9ed9c696d8
-  md5: 9dd9cb9edfe3c3437c28e495a3b67517
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools-1010.6-h40f6528_1.conda
+  sha256: 3e6ab1eb84f55df432af6b1893067c0dfa86e312c04d91824b199c125cf729e1
+  md5: 7e7eb6bef28acef1112673443a8d692b
   depends:
-  - cctools_osx-64 986 h303a5ab_3
-  - ld64 711 ha02d983_3
+  - cctools_osx-64 1010.6 heaa7f0c_1
+  - ld64 951.9 ha02d983_1
   - libllvm16 >=16.0.6,<16.1.0a0
   license: APSL-2.0
   license_family: Other
-  size: 21664
-  timestamp: 1722383826956
+  size: 21588
+  timestamp: 1726771695380
 - kind: conda
   name: cctools
-  version: '986'
-  build: h4faf515_3
-  build_number: 3
+  version: '1010.6'
+  build: h4faf515_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-986-h4faf515_3.conda
-  sha256: c567fe302cf87d0c44902c1f10b8a69e2945570e736b7aedf2094d3b8f08d0cd
-  md5: 9853ea7d96d819f46e04ce1dc8df25f4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1010.6-h4faf515_1.conda
+  sha256: e0a69226e1f70b79f41c471c86fd0c450cc4fd5ec3343cd7689eb1c016babc70
+  md5: d200afcb0b601ad89c79212b9a124347
   depends:
-  - cctools_osx-arm64 986 h670d6a2_3
-  - ld64 711 h634c8be_3
+  - cctools_osx-arm64 1010.6 h4f2c9d0_1
+  - ld64 951.9 h634c8be_1
   - libllvm16 >=16.0.6,<16.1.0a0
   license: APSL-2.0
   license_family: Other
-  size: 21561
-  timestamp: 1722383850044
+  size: 21621
+  timestamp: 1726771337947
 - kind: conda
   name: cctools_osx-64
-  version: '986'
-  build: h303a5ab_3
-  build_number: 3
+  version: '1010.6'
+  build: heaa7f0c_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-986-h303a5ab_3.conda
-  sha256: 7e21d46d1d96625f5fde78e1316d8c13e4ee3391ebe2c4df26dc6f878ddb83b6
-  md5: 3fc65d01538ca026f662f2b13dacc35e
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1010.6-heaa7f0c_1.conda
+  sha256: 2769f7bde9888d100a9997da14aabef345a8ee0850fe2c90e2ca2306e7fe79bd
+  md5: eaedf7d6a7b93b35381f7a0b4663922a
   depends:
   - __osx >=10.13
-  - ld64_osx-64 >=711,<712.0a0
+  - ld64_osx-64 >=951.9,<951.10.0a0
   - libcxx
   - libllvm16 >=16.0.6,<16.1.0a0
   - libzlib >=1.3.1,<2.0a0
+  - llvm-tools 16.0.*
   - sigtool
   constrains:
-  - cctools 986.*
+  - ld64 951.9.*
+  - cctools 1010.6.*
   - clang 16.0.*
-  - ld64 711.*
   license: APSL-2.0
   license_family: Other
-  size: 1097980
-  timestamp: 1722383803979
+  size: 1099432
+  timestamp: 1726771664399
 - kind: conda
   name: cctools_osx-arm64
-  version: '986'
-  build: h670d6a2_3
-  build_number: 3
+  version: '1010.6'
+  build: h4f2c9d0_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-986-h670d6a2_3.conda
-  sha256: 55c114449b5a9c3028f37b74cf38d8d32c496f70f2ca38a3f07638cf4c74478a
-  md5: 446f2bd46d8cf7e5c6aebc81db6c6f08
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1010.6-h4f2c9d0_1.conda
+  sha256: 3585a1d44fae9fd6839734e25ddde9dfb1dbb99c6974deb7bdbc6470b54af76d
+  md5: 3cf0dad98fcf3cec8cf6372ba2954724
   depends:
   - __osx >=11.0
-  - ld64_osx-arm64 >=711,<712.0a0
+  - ld64_osx-arm64 >=951.9,<951.10.0a0
   - libcxx
   - libllvm16 >=16.0.6,<16.1.0a0
   - libzlib >=1.3.1,<2.0a0
+  - llvm-tools 16.0.*
   - sigtool
   constrains:
-  - ld64 711.*
-  - cctools 986.*
+  - ld64 951.9.*
+  - cctools 1010.6.*
   - clang 16.0.*
   license: APSL-2.0
   license_family: Other
-  size: 1092412
-  timestamp: 1722383824126
+  size: 1091944
+  timestamp: 1726771303834
 - kind: conda
   name: ceres-solver
   version: 2.2.0
@@ -2698,60 +2677,58 @@ packages:
 - kind: conda
   name: clang-format-18
   version: 18.1.8
-  build: default_h0c94c6a_3
-  build_number: 3
+  build: default_h0c94c6a_5
+  build_number: 5
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-format-18-18.1.8-default_h0c94c6a_3.conda
-  sha256: 858dec1c5bb518028d7a146776d1e6e2342ea9cc38927efc2038c3d933c27a4c
-  md5: 7b210fb8b29369bc86544031fc2c737f
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-format-18-18.1.8-default_h0c94c6a_5.conda
+  sha256: 84d8b2ec505f3dc124c84a9bc10980707bea94570c07599b97cc0a8702a16f9b
+  md5: c4d5f163037153a64cc8a238ee7403b9
   depends:
   - __osx >=10.13
   - libclang-cpp18.1 >=18.1.8,<18.2.0a0
-  - libcxx >=16
+  - libcxx >=18.1.8
   - libllvm18 >=18.1.8,<18.2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 63077
-  timestamp: 1724894101169
+  size: 62661
+  timestamp: 1726904903860
 - kind: conda
   name: clang-format-18
   version: 18.1.8
-  build: default_h5c12605_3
-  build_number: 3
+  build: default_h5c12605_5
+  build_number: 5
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-18-18.1.8-default_h5c12605_3.conda
-  sha256: 3f528269dfe025f40e58261c22fe374780f8ccf995b22e8b72c8ef56b3ecd37c
-  md5: 3f085f7abec6107d2dadb9815d6192e8
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-18-18.1.8-default_h5c12605_5.conda
+  sha256: 241cdb491b64173e8beab81f6722cc36017b05fb69b5cafc017b73c40907da32
+  md5: 668bcdeda7cf1b690848597837c39424
   depends:
   - __osx >=11.0
   - libclang-cpp18.1 >=18.1.8,<18.2.0a0
-  - libcxx >=16
+  - libcxx >=18.1.8
   - libllvm18 >=18.1.8,<18.2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 61591
-  timestamp: 1724893857127
+  size: 60995
+  timestamp: 1726862751188
 - kind: conda
   name: clang-format-18
   version: 18.1.8
-  build: default_hf981a13_3
-  build_number: 3
+  build: default_hf981a13_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-18-18.1.8-default_hf981a13_3.conda
-  sha256: 6f8cc3784df55cc8e77fbd4df4280b5c0c8fc9ea94fb3d4f69f2f522b0f93668
-  md5: d763fe8bdca823a7661af722834dcac0
+  url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-18-18.1.8-default_hf981a13_5.conda
+  sha256: c4968644d62f1f232947910610ecb0138b61a5f2664cd46f583390096848d9a8
+  md5: 61155bedf5f319502a9ff80d467bdc83
   depends:
   - __glibc >=2.17,<3.0.a0
   - libclang-cpp18.1 >=18.1.8,<18.2.0a0
-  - libgcc
-  - libgcc-ng >=12
+  - libgcc >=12
   - libllvm18 >=18.1.8,<18.2.0a0
-  - libstdcxx
-  - libstdcxx-ng >=12
+  - libstdcxx >=12
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 66984
-  timestamp: 1724894269211
+  size: 66898
+  timestamp: 1726867019534
 - kind: conda
   name: clang_impl_osx-64
   version: 16.0.6
@@ -2985,96 +2962,98 @@ packages:
   timestamp: 1707402842895
 - kind: conda
   name: cmake
-  version: 3.27.6
-  build: h1c59155_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.27.6-h1c59155_0.conda
-  sha256: 31be31e358e6f6f8818d8f9c9086da4404f8c6fc89d71d55887bed11ce6d463e
-  md5: 3c0dd04401438fec44cd113247ba2852
+  version: 3.29.3
+  build: h1304840_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.29.3-h1304840_0.conda
+  sha256: c5359b7985464334a996091e3872be606e52ed6c09bc9a333d54982bdba4cad8
+  md5: 09e5d46cdc7984e4047becf0a1cacd31
   depends:
+  - __osx >=10.13
   - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.3.0,<9.0a0
-  - libcxx >=15.0.7
-  - libexpat >=2.5.0,<3.0a0
-  - libuv >=1.46.0,<2.0a0
+  - libcurl >=8.7.1,<9.0a0
+  - libcxx >=16
+  - libexpat >=2.6.2,<3.0a0
+  - libuv >=1.48.0,<2.0a0
   - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4,<7.0a0
+  - ncurses >=6.5,<7.0a0
   - rhash >=1.4.4,<2.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 16007289
-  timestamp: 1695270816826
+  size: 17475905
+  timestamp: 1715501875099
 - kind: conda
   name: cmake
-  version: 3.27.6
-  build: hcfe8598_0
+  version: 3.29.3
+  build: h2cf84f3_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.29.3-h2cf84f3_0.conda
+  sha256: 163fffdc3fcdf9dfdf29179a8f196ef82a67daaa35a916990bc4e6c21ffdb44c
+  md5: fa714364be420fd992e30fc7ca2e2658
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.7.1,<9.0a0
+  - libcxx >=16
+  - libexpat >=2.6.2,<3.0a0
+  - libuv >=1.48.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.5,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16200400
+  timestamp: 1715502147240
+- kind: conda
+  name: cmake
+  version: 3.29.3
+  build: h91dbaaa_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.27.6-hcfe8598_0.conda
-  sha256: 64e08c246195d6956f7a04fa7d96a53de696b26b1dae8b08cfe716950f696e12
-  md5: 4c0101485c452ea86f846523c4fae698
+  url: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.29.3-h91dbaaa_0.conda
+  sha256: fedf3ae3922cf4e5fe6b7eb24ef788c7b8915830376d23ba53327602dfcc3eec
+  md5: 7d597aedcacb6afeb9303d185c4e8d07
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.3.0,<9.0a0
-  - libexpat >=2.5.0,<3.0a0
+  - libcurl >=8.7.1,<9.0a0
+  - libexpat >=2.6.2,<3.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libuv >=1.46.0,<2.0a0
+  - libuv >=1.48.0,<2.0a0
   - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4,<7.0a0
+  - ncurses >=6.5,<7.0a0
   - rhash >=1.4.4,<2.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 18494905
-  timestamp: 1695269729661
+  size: 18945833
+  timestamp: 1715500207599
 - kind: conda
   name: cmake
-  version: 3.27.6
-  build: hf0feee3_0
+  version: 3.30.1
+  build: h400e5d1_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cmake-3.27.6-hf0feee3_0.conda
-  sha256: 12b94bce6d7c76ff408f8ea240c7d78987b0bc3cb4f632f381c4b0efd30ebfe0
-  md5: 4dc81f3bf26f0949fedd4e31cecea1d1
+  url: https://conda.anaconda.org/conda-forge/win-64/cmake-3.30.1-h400e5d1_0.conda
+  sha256: 60b61fb897210c116e5ce6fb9121788bed20f3f3a4cc10b2604b0804e6907b0c
+  md5: 1c36613e968de2c9eebe9b51f332d323
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.3.0,<9.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libuv >=1.44.2,<2.0a0
-  - libzlib >=1.2.13,<2.0.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libuv >=1.48.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 13777396
-  timestamp: 1695270971791
-- kind: conda
-  name: cmake
-  version: 3.27.6
-  build: hf40c264_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.27.6-hf40c264_0.conda
-  sha256: 9216698f88b82e99db950f8c372038931c54ea3e0b0b05e2a3ce03ec4b405df7
-  md5: 771da6a52aaf0f9d84114d0ed0d0299f
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.3.0,<9.0a0
-  - libcxx >=15.0.7
-  - libexpat >=2.5.0,<3.0a0
-  - libuv >=1.46.0,<2.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4,<7.0a0
-  - rhash >=1.4.4,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 16525734
-  timestamp: 1695270838345
+  size: 14424822
+  timestamp: 1721338354615
 - kind: conda
   name: colorama
   version: 0.4.6
@@ -3179,220 +3158,6 @@ packages:
   size: 9829914
   timestamp: 1701467293179
 - kind: conda
-  name: cuda-cccl
-  version: 12.6.37
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-cccl-12.6.37-0.tar.bz2
-  sha256: 724fe81f51bf579a380b96248dafec85cbae93f9178c1f6e6d59daed6d738eb4
-  md5: 2dc5a23af0bf91bbb9ba23caf36e9427
-  depends:
-  - cuda-cccl_win-64 12.6.37
-  - cuda-version >=12.6,<12.7.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 16588
-  timestamp: 1721098318658
-- kind: conda
-  name: cuda-cccl_win-64
-  version: 12.6.37
-  build: '0'
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/nvidia/noarch/cuda-cccl_win-64-12.6.37-0.tar.bz2
-  sha256: d348711e3a27a6a75fa3a635f91d4b8abbfbc652a44a7a62c4058748f12ef3dd
-  md5: 96630c6083a8eb0426ab0ef93190b7bb
-  depends:
-  - cuda-version >=12.6,<12.7.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1410511
-  timestamp: 1721098308211
-- kind: conda
-  name: cuda-cudart
-  version: 12.4.127
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-12.4.127-0.tar.bz2
-  sha256: db4c8b924800e9232cf6c9294597c4485f94c637252dbc0ef20fee450279a8b8
-  md5: beb86e539e40cb2ddba9b2f897cc4da1
-  size: 1028527
-  timestamp: 1710545430234
-- kind: conda
-  name: cuda-cudart-dev
-  version: 12.4.127
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-dev-12.4.127-0.tar.bz2
-  sha256: cf87e1dfe93407d8e4dc85683568fcbbc55c76e98d770615a1e09822a21998d5
-  md5: 86051f568f1f3810548939c9e540cea5
-  depends:
-  - cuda-cccl
-  - cuda-cudart >=12.4.127
-  size: 611628
-  timestamp: 1710545502261
-- kind: conda
-  name: cuda-cupti
-  version: 12.4.127
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-cupti-12.4.127-0.tar.bz2
-  sha256: 3c4e89d1ee24053bda3dda876b5bd087d6c52b54ba020cec61098ea2c653a389
-  md5: 2e04ac4d039f4a44a9743c14c4082c5b
-  size: 13532691
-  timestamp: 1710543364860
-- kind: conda
-  name: cuda-libraries
-  version: 12.4.0
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-12.4.0-0.tar.bz2
-  sha256: cfad10e981b75ab9565c758121727c5e6269bfdcf9cfa0206c387046985c6773
-  md5: 275c82169936ce18289d7bddc4e6abbd
-  depends:
-  - cuda-cudart >=12.4.99
-  - cuda-nvrtc >=12.4.99
-  - cuda-opencl >=12.4.99
-  - libcublas >=12.4.2.65
-  - libcufft >=11.2.0.44
-  - libcurand >=10.3.5.119
-  - libcusolver >=11.6.0.99
-  - libcusparse >=12.3.0.142
-  - libnpp >=12.2.5.2
-  - libnvfatbin >=12.4.99
-  - libnvjitlink >=12.4.99
-  - libnvjpeg >=12.3.1.89
-  size: 1869
-  timestamp: 1709168022172
-- kind: conda
-  name: cuda-libraries-dev
-  version: 12.4.0
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-dev-12.4.0-0.tar.bz2
-  sha256: 82610cfb4b6643b2111fc5d7188d1c2d7048df0a98666cfe595439d75be42102
-  md5: 790354c4cbf6fd6ce09599e00f8834fc
-  depends:
-  - cuda-cccl >=12.4.99
-  - cuda-cudart-dev >=12.4.99
-  - cuda-nvrtc-dev >=12.4.99
-  - cuda-opencl-dev >=12.4.99
-  - cuda-profiler-api >=12.4.99
-  - libcublas-dev >=12.4.2.65
-  - libcufft-dev >=11.2.0.44
-  - libcurand-dev >=10.3.5.119
-  - libcusolver-dev >=11.6.0.99
-  - libcusparse-dev >=12.3.0.142
-  - libnpp-dev >=12.2.5.2
-  - libnvfatbin-dev >=12.4.99
-  - libnvjitlink-dev >=12.4.99
-  - libnvjpeg-dev >=12.3.1.89
-  size: 1884
-  timestamp: 1709168083870
-- kind: conda
-  name: cuda-nvrtc
-  version: 12.4.127
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-12.4.127-0.tar.bz2
-  sha256: ce33b6f96560f48515e27afec5616d60d9c0109bbf4da0392a1e929b515567f0
-  md5: 6322ce93990aeed889b69255fa04a5f8
-  size: 81791963
-  timestamp: 1710544344596
-- kind: conda
-  name: cuda-nvrtc-dev
-  version: 12.4.127
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-dev-12.4.127-0.tar.bz2
-  sha256: c022188647d9809e5c6b4a3c50ecc9bc6c80f05466223f8cfff0c9521456cdb5
-  md5: c5f15dced260e0353a65b043dea2562b
-  depends:
-  - cuda-nvrtc >=12.4.127
-  size: 18063913
-  timestamp: 1710544480124
-- kind: conda
-  name: cuda-nvtx
-  version: 12.4.127
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvtx-12.4.127-0.tar.bz2
-  sha256: 09fb6f1e33a866ed91fc86c2e53e86e43a4b406dc2584b6d05f92ae56b13ba2a
-  md5: 091f53e67f8e42bcfa13665d9aa0c3ab
-  size: 42129
-  timestamp: 1710541051423
-- kind: conda
-  name: cuda-opencl
-  version: 12.6.68
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-opencl-12.6.68-0.tar.bz2
-  sha256: 84f29b57124469663f0fb49fb2b743b87001f50d581a6967e5ad99d0f6b808e3
-  md5: f3fa339f67d0c23e24e7c64a41306ed6
-  depends:
-  - cuda-version >=12.6,<12.7.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 16627
-  timestamp: 1723660760509
-- kind: conda
-  name: cuda-opencl-dev
-  version: 12.6.68
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-opencl-dev-12.6.68-0.tar.bz2
-  sha256: fdc48b85318b8891041d09cdd4733c633623e043e887f38a35d9012a5682a4e4
-  md5: b42db3877330da605c8aa680257f435f
-  depends:
-  - cuda-opencl 12.6.68 0
-  - cuda-version >=12.6,<12.7.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 97330
-  timestamp: 1723660763668
-- kind: conda
-  name: cuda-profiler-api
-  version: 12.6.68
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-profiler-api-12.6.68-0.tar.bz2
-  sha256: d536611e510389ea5e7f78b78ad359aad9402f687f0388adc1c1e56c9289dbd1
-  md5: 0d85c9f57f23ba3e43aac9a3cdeef54d
-  depends:
-  - cuda-cudart-dev
-  - cuda-version >=12.6,<12.7.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 19438
-  timestamp: 1723661164189
-- kind: conda
-  name: cuda-runtime
-  version: 12.4.0
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-runtime-12.4.0-0.tar.bz2
-  sha256: 7b2a3a278633cdda9688b4b20c555aa8a6edc5f67120871bf5b998a9c535bfd8
-  md5: 93db4b379ae5cc7ee2574e3d95c4298e
-  depends:
-  - cuda-libraries >=12.4.0
-  size: 1752
-  timestamp: 1709168331244
-- kind: conda
-  name: cuda-version
-  version: '12.6'
-  build: '3'
-  build_number: 3
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/nvidia/noarch/cuda-version-12.6-3.tar.bz2
-  sha256: 9f6333ecdbbb213d7c316cfa00055d56e5a4016ea16ec3b885310f10f07ce0bd
-  md5: 490a49513fa92797bb5336ae329688bf
-  constrains:
-  - __cuda >=12
-  - cudatoolkit 12.6|12.6.*
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 16589
-  timestamp: 1722029877075
-- kind: conda
   name: cxx-compiler
   version: 1.7.0
   build: h00ab1b0_1
@@ -3474,71 +3239,69 @@ packages:
 - kind: conda
   name: dispenso
   version: 1.3.0
-  build: h5888daf_4
-  build_number: 4
+  build: h5888daf_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/dispenso-1.3.0-h5888daf_4.conda
-  sha256: 6dc3bc2bf6a60554f25e87fbb6348e75010e9aa97c4849b600c0ef7fae8a0d3b
-  md5: 9ca68c8f957c881171d3c6410625e9d4
+  url: https://conda.anaconda.org/conda-forge/linux-64/dispenso-1.3.0-h5888daf_5.conda
+  sha256: ae7978aa6468ce12da3aea570eb6240fd8e57986fcc5c1f57b18f1e77d05ee75
+  md5: b087ed9c3f303a6344a97f1494b1b111
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libgcc-ng
   - libstdcxx >=13
-  - libstdcxx-ng
   license: MIT
   license_family: MIT
-  size: 177527
-  timestamp: 1724952464520
+  size: 178197
+  timestamp: 1725205721270
 - kind: conda
   name: dispenso
   version: 1.3.0
-  build: hac325c4_4
-  build_number: 4
+  build: hac325c4_5
+  build_number: 5
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/dispenso-1.3.0-hac325c4_4.conda
-  sha256: 90f05a090338cbb2deb041edd62252314152df87dc19fa7cacfe4e9609e156c4
-  md5: e8329bfb7770cedb4f244391b98aa806
+  url: https://conda.anaconda.org/conda-forge/osx-64/dispenso-1.3.0-hac325c4_5.conda
+  sha256: 16268a086b5bf1b54ff6335f99f50a84cc458609f8258f04d2868b51a1468e9c
+  md5: f6db8256eef772a1fdc5d88e473d96de
   depends:
   - __osx >=10.13
   - libcxx >=17
   license: MIT
   license_family: MIT
-  size: 174569
-  timestamp: 1724952522012
+  size: 174760
+  timestamp: 1725205777437
 - kind: conda
   name: dispenso
   version: 1.3.0
-  build: he0c23c2_4
-  build_number: 4
+  build: he0c23c2_5
+  build_number: 5
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/dispenso-1.3.0-he0c23c2_4.conda
-  sha256: e70b8ac657f16780956bd3d4b1ba88a058f63c83ac9636e7d1308a0e587def72
-  md5: 15d28aff1ce876eb51fabe2add001ec4
+  url: https://conda.anaconda.org/conda-forge/win-64/dispenso-1.3.0-he0c23c2_5.conda
+  sha256: daf51f62d519df58c12c82b0164fb75a828860233f667fa76fcffd0ca0c5496f
+  md5: 3610c86315fad172ff97cdab4cebd1d3
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 197258
-  timestamp: 1720378912923
+  size: 197310
+  timestamp: 1725206218855
 - kind: conda
   name: dispenso
   version: 1.3.0
-  build: hf9b8971_4
-  build_number: 4
+  build: hf9b8971_5
+  build_number: 5
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/dispenso-1.3.0-hf9b8971_4.conda
-  sha256: f7a45eb6a5b6b65c8b50188a6bd2e7ab21e6b43900a9733b9ac329b44c83aacd
-  md5: 3a95d82d76307518e3e25301dfc8bc30
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/dispenso-1.3.0-hf9b8971_5.conda
+  sha256: 572f7edc86c402af867618663f712166c6fdff4c0040d407609d27eb556d012f
+  md5: 2532232c3c93bc83a923b3fce73a04ef
   depends:
   - __osx >=11.0
   - libcxx >=17
   license: MIT
   license_family: MIT
-  size: 170489
-  timestamp: 1724952723617
+  size: 170125
+  timestamp: 1725205737822
 - kind: conda
   name: drjit-cpp
   version: 0.4.6
@@ -3680,19 +3443,19 @@ packages:
   timestamp: 1720869435725
 - kind: conda
   name: executing
-  version: 2.0.1
+  version: 2.1.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-  sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
-  md5: e16be50e378d8a4533b989035b196ab8
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+  sha256: a52d7516e2e11d3eb10908e10d3eb3f8ef267fea99ed9b09d52d96c4db3441b8
+  md5: d0441db20c827c11721889a241df1220
   depends:
   - python >=2.7
   license: MIT
   license_family: MIT
-  size: 27689
-  timestamp: 1698580072627
+  size: 28337
+  timestamp: 1725214501850
 - kind: conda
   name: ezc3d
   version: 1.5.9
@@ -3767,18 +3530,18 @@ packages:
   timestamp: 1708021067299
 - kind: conda
   name: filelock
-  version: 3.15.4
+  version: 3.16.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
-  sha256: f78d9c0be189a77cb0c67d02f33005f71b89037a85531996583fb79ff3fe1a0a
-  md5: 0e7e4388e9d5283e22b35a9443bdbcc9
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_0.conda
+  sha256: 1da766da9dba05091af87977922fe60dc7464091a9ccffb3765d403189d39be4
+  md5: 916f8ec5dd4128cd5f207a3c4c07b2c6
   depends:
   - python >=3.7
   license: Unlicense
-  size: 17592
-  timestamp: 1719088395353
+  size: 17357
+  timestamp: 1726613593584
 - kind: conda
   name: fmt
   version: 10.2.1
@@ -3904,19 +3667,19 @@ packages:
   timestamp: 1694616398888
 - kind: conda
   name: fsspec
-  version: 2024.6.1
+  version: 2024.9.0
   build: pyhff2d567_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
-  sha256: 2b8e98294c70d9a33ee0ef27539a8a8752a26efeafa0225e85dc876ef5bb49f4
-  md5: 996bf792cdb8c0ac38ff54b9fde56841
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.9.0-pyhff2d567_0.conda
+  sha256: 8f4e9805b4ec223dea0d99f9e7e57c391d9026455eb9f0d6e0784c5d1a1200dc
+  md5: ace4329fbff4c69ab0309db6da182987
   depends:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
-  size: 133141
-  timestamp: 1719515065535
+  size: 134378
+  timestamp: 1725543368393
 - kind: conda
   name: fx-gltf
   version: 2.0.0
@@ -4024,82 +3787,86 @@ packages:
 - kind: conda
   name: gcc_linux-64
   version: 12.4.0
-  build: h6b7512a_1
-  build_number: 1
+  build: h6b7512a_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.4.0-h6b7512a_1.conda
-  sha256: fe2dd04ca56f142f1d8e629e35337167596a266f67eeb983a5635645d125a3ee
-  md5: e55a442a2224a914914d8717d2fbd6da
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.4.0-h6b7512a_3.conda
+  sha256: 1f081cd6115ef27c40972d1b939af160c66e07f5341687b2197239b1bbf00bfd
+  md5: 708f7badfa630591f013e9c6b3597d3c
   depends:
-  - binutils_linux-64 2.40 hb3c18ed_1
+  - binutils_linux-64 2.40 hb3c18ed_3
   - gcc_impl_linux-64 12.4.0.*
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
-  size: 31282
-  timestamp: 1724910059160
+  size: 31863
+  timestamp: 1726699135269
 - kind: conda
   name: gflags
   version: 2.2.2
-  build: ha925a31_1004
-  build_number: 1004
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gflags-2.2.2-ha925a31_1004.tar.bz2
-  sha256: d2dbb918efa9c89ead501347cce753bdbac3f5426d42ae5f48eee73790757f54
-  md5: e9442160f56fa442d4ff3eb2e4cf0f22
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 82263
-  timestamp: 1594304231182
-- kind: conda
-  name: gflags
-  version: 2.2.2
-  build: hb1e8313_1004
-  build_number: 1004
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
-  sha256: 39540f879057ae529cad131644af111a8c3c48b384ec6212de6a5381e0863948
-  md5: 3f59cc77a929537e42120faf104e0d16
-  depends:
-  - libcxx >=10.0.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 94612
-  timestamp: 1599590973213
-- kind: conda
-  name: gflags
-  version: 2.2.2
-  build: hc88da5d_1004
-  build_number: 1004
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
-  sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
-  md5: aab9ddfad863e9ef81229a1f8852211b
-  depends:
-  - libcxx >=11.0.0.rc1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 86690
-  timestamp: 1599590990520
-- kind: conda
-  name: gflags
-  version: 2.2.2
-  build: he1b5a44_1004
-  build_number: 1004
+  build: h5888daf_1005
+  build_number: 1005
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
-  sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
-  md5: cddaf2c63ea4a5901cf09524c490ecdc
+  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+  sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
+  md5: d411fc29e338efb48c5fd4576d71d881
   depends:
-  - libgcc-ng >=7.5.0
-  - libstdcxx-ng >=7.5.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   license: BSD-3-Clause
   license_family: BSD
-  size: 116549
-  timestamp: 1594303828933
+  size: 119654
+  timestamp: 1726600001928
+- kind: conda
+  name: gflags
+  version: 2.2.2
+  build: hac325c4_1005
+  build_number: 1005
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+  sha256: c0bea66f71a6f4baa8d4f0248e17f65033d558d9e882c0af571b38bcca3e4b46
+  md5: a26de8814083a6971f14f9c8c3cb36c2
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84946
+  timestamp: 1726600054963
+- kind: conda
+  name: gflags
+  version: 2.2.2
+  build: he0c23c2_1005
+  build_number: 1005
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/gflags-2.2.2-he0c23c2_1005.conda
+  sha256: 4f3c7a4c1ed660737fe4a8d73cbb1770d10bc0fc64ad6391dfa9667fbc898664
+  md5: 9b088c904c7d06d17363682e42ecf403
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76765
+  timestamp: 1726600357514
+- kind: conda
+  name: gflags
+  version: 2.2.2
+  build: hf9b8971_1005
+  build_number: 1005
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+  sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
+  md5: 57a511a5905caa37540eb914dfcbf1fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82090
+  timestamp: 1726600145480
 - kind: conda
   name: glog
   version: 0.7.1
@@ -4213,34 +3980,14 @@ packages:
 - kind: conda
   name: gmpy2
   version: 2.1.5
-  build: py312h1d5cde6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.1.5-py312h1d5cde6_1.conda
-  sha256: afe8fd8bacbb345bdeba6ae275dba6bda6ce9f5f7e1a0c658fff40373fae4654
-  md5: 27abd7664bc87595bd98b6306b8393d1
-  depends:
-  - gmp >=6.3.0,<7.0a0
-  - libgcc-ng >=12
-  - mpc >=1.3.1,<2.0a0
-  - mpfr >=4.2.1,<5.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  size: 212406
-  timestamp: 1715527440339
-- kind: conda
-  name: gmpy2
-  version: 2.1.5
-  build: py312hd98c385_1
-  build_number: 1
+  build: py312h165121d_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmpy2-2.1.5-py312hd98c385_1.conda
-  sha256: 23066e588d3e371c556e5439c1df3399f267c633f85d3b76c6aca9584e634398
-  md5: 61eb95ccf29fae77bc94a70fd8acbd22
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmpy2-2.1.5-py312h165121d_2.conda
+  sha256: 07e0c98c27e4b18688cc2eed685331fbb22e6414c17fca8e855f50c1e168ffa3
+  md5: 49626bac2c903d27984a6c3428134362
   depends:
-  - __osx >=10.9
+  - __osx >=10.13
   - gmp >=6.3.0,<7.0a0
   - mpc >=1.3.1,<2.0a0
   - mpfr >=4.2.1,<5.0a0
@@ -4248,17 +3995,38 @@ packages:
   - python_abi 3.12.* *_cp312
   license: LGPL-3.0-or-later
   license_family: LGPL
-  size: 155260
-  timestamp: 1715527543826
+  size: 155394
+  timestamp: 1725379926956
 - kind: conda
   name: gmpy2
   version: 2.1.5
-  build: py312hfa9fade_1
-  build_number: 1
+  build: py312h7201bc8_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.1.5-py312h7201bc8_2.conda
+  sha256: 66665fbf074e9cc8975ba1a0c7d4fd378cea6efc7ba34f0da5a355a16dfb323a
+  md5: af9faf103fb57241246416dc70b466f7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gmp >=6.3.0,<7.0a0
+  - libgcc >=13
+  - mpc >=1.3.1,<2.0a0
+  - mpfr >=4.2.1,<5.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 211651
+  timestamp: 1725379960923
+- kind: conda
+  name: gmpy2
+  version: 2.1.5
+  build: py312h87fada9_2
+  build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.1.5-py312hfa9fade_1.conda
-  sha256: a8b23b61b0c217d765528849c9c2377fe1967a266d786c3646588bfb1c9a792c
-  md5: fe03ded0dd16d91a42d7467e9c1457f1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.1.5-py312h87fada9_2.conda
+  sha256: a41f68fc4016813f285bec42157a19030a8e9aca8ffcd7e89bbfb7f6ea9e605f
+  md5: 2f3497178aaeec7e4811bc8a2426cae8
   depends:
   - __osx >=11.0
   - gmp >=6.3.0,<7.0a0
@@ -4269,8 +4037,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: LGPL-3.0-or-later
   license_family: LGPL
-  size: 148826
-  timestamp: 1715527621898
+  size: 148575
+  timestamp: 1725380166808
 - kind: conda
   name: gtest
   version: 1.15.2
@@ -4378,21 +4146,21 @@ packages:
 - kind: conda
   name: gxx_linux-64
   version: 12.4.0
-  build: h8489865_1
-  build_number: 1
+  build: h8489865_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.4.0-h8489865_1.conda
-  sha256: 8cf86a8caca64fcba09dc8ea78221b539a277a2b63bfef91557c1a6527cf9504
-  md5: 7d42368fd1828a144175ff3da449d2fa
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.4.0-h8489865_3.conda
+  sha256: 05a6bc65efb637d4fed385e70a3fb44931ac93f9c4cd3b22d42abf22499e57de
+  md5: c08720a66d71a1bf89f257ca93ac9122
   depends:
-  - binutils_linux-64 2.40 hb3c18ed_1
-  - gcc_linux-64 12.4.0 h6b7512a_1
+  - binutils_linux-64 2.40 hb3c18ed_3
+  - gcc_linux-64 12.4.0 h6b7512a_3
   - gxx_impl_linux-64 12.4.0.*
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
-  size: 29631
-  timestamp: 1724910075881
+  size: 30186
+  timestamp: 1726699154203
 - kind: conda
   name: icu
   version: '75.1'
@@ -4439,19 +4207,19 @@ packages:
   timestamp: 1720853997952
 - kind: conda
   name: idna
-  version: '3.8'
+  version: '3.10'
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.8-pyhd8ed1ab_0.conda
-  sha256: 8660d38b272d3713ec8ac5ae918bc3bc80e1b81e1a7d61df554bded71ada6110
-  md5: 99e164522f6bdf23c177c8d9ae63f975
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+  sha256: 8c57fd68e6be5eecba4462e983aed7e85761a519aab80e834bbd7794d4b545b2
+  md5: 7ba2ede0e7c795ff95088daf0dc59753
   depends:
   - python >=3.6
   license: BSD-3-Clause
   license_family: BSD
-  size: 49275
-  timestamp: 1724450633325
+  size: 49837
+  timestamp: 1726459583613
 - kind: conda
   name: iniconfig
   version: 2.0.0
@@ -4730,7 +4498,7 @@ packages:
   md5: d3592435917b62a8becff3a60db674f6
   depends:
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -4748,7 +4516,7 @@ packages:
   md5: 66f6c134e76fe13cce8a9ea5814b5dd5
   depends:
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   license: MIT
   license_family: MIT
   size: 211959
@@ -4763,7 +4531,7 @@ packages:
   md5: 1442db8f03517834843666c422238c9b
   depends:
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   license: MIT
   license_family: MIT
   size: 224432
@@ -4779,97 +4547,97 @@ packages:
   depends:
   - libgcc-ng >=12
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   license: MIT
   license_family: MIT
   size: 245247
   timestamp: 1701647787198
 - kind: conda
   name: ld64
-  version: '711'
-  build: h634c8be_3
-  build_number: 3
+  version: '951.9'
+  build: h634c8be_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-711-h634c8be_3.conda
-  sha256: 66c39759e39b403fb02c6d746636ec5f182c15b7af2f9699d2a69a58ed05e37b
-  md5: 3408bc5ef55bcf2503d7f48ce93d74fb
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-951.9-h634c8be_1.conda
+  sha256: d347ecd273ea7552ae703a37650ea211ff640ed8fd921fe6f1ede49dcdc1358c
+  md5: 294a282b67deea1f0ea1c7d8be2bb5c5
   depends:
-  - ld64_osx-arm64 711 h4c89ff5_3
+  - ld64_osx-arm64 951.9 h0605c9f_1
   - libllvm16 >=16.0.6,<16.1.0a0
   constrains:
-  - cctools_osx-arm64 986.*
-  - cctools 986.*
+  - cctools_osx-arm64 1010.6.*
+  - cctools 1010.6.*
   license: APSL-2.0
   license_family: Other
-  size: 18898
-  timestamp: 1722383839119
+  size: 18928
+  timestamp: 1726771322773
 - kind: conda
   name: ld64
-  version: '711'
-  build: ha02d983_3
-  build_number: 3
+  version: '951.9'
+  build: ha02d983_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ld64-711-ha02d983_3.conda
-  sha256: f0dc96e68ff276a746657290cd0c21613e4f01c26bbf32aff6f7ace8f74b8591
-  md5: c28c578f9791983a2a9dd480d120d562
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64-951.9-ha02d983_1.conda
+  sha256: 4a27102c8451ce30b3c2d90722826e8bd02e9bb3b92cd5afaa08c65bbe6447f5
+  md5: 8991ffc3c5c410692d8740de4cb92849
   depends:
-  - ld64_osx-64 711 h04ffbf3_3
+  - ld64_osx-64 951.9 h3516399_1
   - libllvm16 >=16.0.6,<16.1.0a0
   constrains:
-  - cctools_osx-64 986.*
-  - cctools 986.*
+  - cctools 1010.6.*
+  - cctools_osx-64 1010.6.*
   license: APSL-2.0
   license_family: Other
-  size: 18849
-  timestamp: 1722383816051
+  size: 18850
+  timestamp: 1726771680769
 - kind: conda
   name: ld64_osx-64
-  version: '711'
-  build: h04ffbf3_3
-  build_number: 3
+  version: '951.9'
+  build: h3516399_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-711-h04ffbf3_3.conda
-  sha256: 65ea151f97a583fe1c650a512cdecc8c92748f26918c2734e1bdabe0b6c21dd3
-  md5: 944906b249119ecff9139acf7d1f2574
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-951.9-h3516399_1.conda
+  sha256: 03417d5a379bf8e7b2ac99000d9af836cae53b843e02de7cea066c4ddd88767c
+  md5: 4656f00ccd13a49804387450302c4f45
   depends:
   - __osx >=10.13
   - libcxx
   - libllvm16 >=16.0.6,<16.1.0a0
   - sigtool
-  - tapi >=1100.0.11,<1101.0a0
+  - tapi >=1300.6.5,<1301.0a0
   constrains:
-  - cctools_osx-64 986.*
-  - ld 711.*
-  - cctools 986.*
   - clang >=16.0.6,<17.0a0
+  - cctools 1010.6.*
+  - cctools_osx-64 1010.6.*
+  - ld 951.9.*
   license: APSL-2.0
   license_family: Other
-  size: 1096494
-  timestamp: 1722383732457
+  size: 1088101
+  timestamp: 1726771578888
 - kind: conda
   name: ld64_osx-arm64
-  version: '711'
-  build: h4c89ff5_3
-  build_number: 3
+  version: '951.9'
+  build: h0605c9f_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-711-h4c89ff5_3.conda
-  sha256: de6b2f5fb30fb39497122ff52fd02d2044549388bd0e7ddb9f013917ad59e9d5
-  md5: 55c7903ba7e6813d23aed6940ba3f00e
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-951.9-h0605c9f_1.conda
+  sha256: 2183f5fc32084bbaa83a84817cfc68091e9e739a048a185dcfa55be908b9fe54
+  md5: 77076839b5a8ac684c7971641d69b97a
   depends:
   - __osx >=11.0
   - libcxx
   - libllvm16 >=16.0.6,<16.1.0a0
   - sigtool
-  - tapi >=1100.0.11,<1101.0a0
+  - tapi >=1300.6.5,<1301.0a0
   constrains:
-  - cctools_osx-arm64 986.*
-  - ld 711.*
   - clang >=16.0.6,<17.0a0
-  - cctools 986.*
+  - cctools_osx-arm64 1010.6.*
+  - ld 951.9.*
+  - cctools 1010.6.*
   license: APSL-2.0
   license_family: Other
-  size: 1013664
-  timestamp: 1722383762935
+  size: 1006497
+  timestamp: 1726771248963
 - kind: conda
   name: ld_impl_linux-64
   version: '2.40'
@@ -5668,69 +5436,6 @@ packages:
 - kind: conda
   name: libblas
   version: 3.9.0
-  build: 22_osx64_openblas
-  build_number: 22
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-22_osx64_openblas.conda
-  sha256: d72060239f904b3a81d2329efcf84dc62c2dfd66dbc4efc8dcae1afdf8f02b59
-  md5: b80966a8c8dd0b531f8e65f709d732e8
-  depends:
-  - libopenblas >=0.3.27,<0.3.28.0a0
-  - libopenblas >=0.3.27,<1.0a0
-  constrains:
-  - liblapacke 3.9.0 22_osx64_openblas
-  - blas * openblas
-  - libcblas 3.9.0 22_osx64_openblas
-  - liblapack 3.9.0 22_osx64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14749
-  timestamp: 1712542279018
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 23_linux64_openblas
-  build_number: 23
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-23_linux64_openblas.conda
-  sha256: edb1cee5da3ac4936940052dcab6969673ba3874564f90f5110f8c11eed789c2
-  md5: 96c8450a40aa2b9733073a9460de972c
-  depends:
-  - libopenblas >=0.3.27,<0.3.28.0a0
-  - libopenblas >=0.3.27,<1.0a0
-  constrains:
-  - liblapacke 3.9.0 23_linux64_openblas
-  - libcblas 3.9.0 23_linux64_openblas
-  - liblapack 3.9.0 23_linux64_openblas
-  - blas * openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14880
-  timestamp: 1721688759937
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 23_osxarm64_openblas
-  build_number: 23
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-23_osxarm64_openblas.conda
-  sha256: 1c30da861e306a25fac8cd30ce0c1b31c9238d04e7768c381cf4d431b4361e6c
-  md5: acae9191e8772f5aff48ab5232d4d2a3
-  depends:
-  - libopenblas >=0.3.27,<0.3.28.0a0
-  - libopenblas >=0.3.27,<1.0a0
-  constrains:
-  - liblapack 3.9.0 23_osxarm64_openblas
-  - blas * openblas
-  - liblapacke 3.9.0 23_osxarm64_openblas
-  - libcblas 3.9.0 23_osxarm64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 15103
-  timestamp: 1721688997980
-- kind: conda
-  name: libblas
-  version: 3.9.0
   build: 23_win64_mkl
   build_number: 23
   subdir: win-64
@@ -5749,37 +5454,98 @@ packages:
   size: 5192100
   timestamp: 1721689573083
 - kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 24_linux64_openblas
+  build_number: 24
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-24_linux64_openblas.conda
+  sha256: 3097f7913bda527d4fe9f824182b314e130044e582455037fca6f4e97965d83c
+  md5: 80aea6603a6813b16ec119d00382b772
+  depends:
+  - libopenblas >=0.3.27,<0.3.28.0a0
+  - libopenblas >=0.3.27,<1.0a0
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 24_linux64_openblas
+  - libcblas 3.9.0 24_linux64_openblas
+  - liblapacke 3.9.0 24_linux64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14981
+  timestamp: 1726668454790
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 24_osx64_blis
+  build_number: 24
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-24_osx64_blis.conda
+  sha256: 992fc1c46cafadbf4d40186c1d12e646e1b40a7f3e608923f0f5efedab04d0de
+  md5: 8adfc7d9ae7eec6dedf816f54ae1bf4f
+  depends:
+  - blis >=0.9.0,<0.9.1.0a0
+  constrains:
+  - blas * blis
+  - libcblas 3.9.0 24_osx64_blis
+  track_features:
+  - blas_blis
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15046
+  timestamp: 1726668625955
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 24_osxarm64_openblas
+  build_number: 24
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-24_osxarm64_openblas.conda
+  sha256: 4739f7463efb12e6d71536d8b0285a8de5aaadcc442bfedb9d92d1b4cbc47847
+  md5: 35cb711e7bc46ee5f3dd67af99ad1986
+  depends:
+  - libopenblas >=0.3.27,<0.3.28.0a0
+  - libopenblas >=0.3.27,<1.0a0
+  constrains:
+  - liblapack 3.9.0 24_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 24_osxarm64_openblas
+  - libcblas 3.9.0 24_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15144
+  timestamp: 1726668802976
+- kind: conda
   name: libboost
   version: 1.84.0
-  build: h0ccab89_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.84.0-h0ccab89_5.conda
-  sha256: f66f16ce2402eedb58f4cf1a09b4edfab644e540bb287fe65a7d52f529fe00d1
-  md5: b26bd978e55fad1d173ea96c1c50c6c2
+  build: h29978a0_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.84.0-h29978a0_6.conda
+  sha256: ee8cc3e537b4d8463ea50174d3b1b5b24734c9d7ed408f59b2ebe927c572bdc9
+  md5: 232a691ea64686f84493f0822388aa99
   depends:
-  - __glibc >=2.17,<3.0.a0
+  - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
   - icu >=75.1,<76.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - libcxx >=17
   - libzlib >=1.3.1,<2.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   constrains:
   - boost-cpp =1.84.0
   license: BSL-1.0
-  size: 2857449
-  timestamp: 1722289875483
+  size: 1957364
+  timestamp: 1725326644452
 - kind: conda
   name: libboost
   version: 1.84.0
-  build: h444863b_5
-  build_number: 5
+  build: h444863b_6
+  build_number: 6
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-1.84.0-h444863b_5.conda
-  sha256: 20bbc904bf20981211f124027402a0e34bdcf15f92dabfbecd54b4f6bc1ac370
-  md5: 92d25c5b7de60c0b262fe747fbe9d928
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-1.84.0-h444863b_6.conda
+  sha256: 35b268b5ba31a6a4672b260905dac64a05e8801199d11d934b1a766897612cc9
+  md5: 51b2f4207c1c2fc0b89de6dab95699a6
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libiconv >=1.17,<2.0a0
@@ -5792,338 +5558,276 @@ packages:
   constrains:
   - boost-cpp =1.84.0
   license: BSL-1.0
-  size: 2413653
-  timestamp: 1722291119070
+  size: 2340139
+  timestamp: 1725326974927
 - kind: conda
   name: libboost
   version: 1.84.0
-  build: hcca3243_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.84.0-hcca3243_5.conda
-  sha256: 32f85a881925b53604aee10555b42d5ce342e04161324a0e70641dfd5c218261
-  md5: 50b14e5f00cb8ac0b00327b240ca42c1
-  depends:
-  - __osx >=10.13
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=75.1,<76.0a0
-  - libcxx >=16
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 2057133
-  timestamp: 1722290090578
-- kind: conda
-  name: libboost
-  version: 1.84.0
-  build: hf763ba5_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.84.0-hf763ba5_5.conda
-  sha256: bc062255f12620e25abbb6763570bea2de16e7e0c6c70683b95c89a87e44ac45
-  md5: 07a9525dff569e0528858fccbd4c2128
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=75.1,<76.0a0
-  - libcxx >=16
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 1891339
-  timestamp: 1722290449613
-- kind: conda
-  name: libboost-devel
-  version: 1.84.0
-  build: h00ab1b0_5
-  build_number: 5
+  build: hb8260a3_6
+  build_number: 6
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.84.0-h00ab1b0_5.conda
-  sha256: f126001a1f8ef95ea56dbd93767f3a54f26dc1b555e5bf1484d69edd228b9c43
-  md5: 8781c46806d1a66c50676614f0dcc2df
-  depends:
-  - libboost 1.84.0 h0ccab89_5
-  - libboost-headers 1.84.0 ha770c72_5
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 39471
-  timestamp: 1722289996647
-- kind: conda
-  name: libboost-devel
-  version: 1.84.0
-  build: h2b186f8_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-devel-1.84.0-h2b186f8_5.conda
-  sha256: 7d54eee42b52e38498687a90d52a0721072dacbf248e2867475689a362934fc6
-  md5: a1abad26a3771b0c332c76163d73c88d
-  depends:
-  - libboost 1.84.0 hcca3243_5
-  - libboost-headers 1.84.0 h694c41f_5
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 40510
-  timestamp: 1722290253605
-- kind: conda
-  name: libboost-devel
-  version: 1.84.0
-  build: h91493d7_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-devel-1.84.0-h91493d7_5.conda
-  sha256: 82241c90f9564cd8a8316efc5937158854f282908ff152fdfa3d2b1f2c06a961
-  md5: 978d58f100bb759089ef28a48449f610
-  depends:
-  - libboost 1.84.0 h444863b_5
-  - libboost-headers 1.84.0 h57928b3_5
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 41698
-  timestamp: 1722291418618
-- kind: conda
-  name: libboost-devel
-  version: 1.84.0
-  build: hf450f58_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-devel-1.84.0-hf450f58_5.conda
-  sha256: 2004da865aefc473bba5b1401e259358a2598723d9bb8fa96243ea20138000a4
-  md5: 5b8b4202436f3e8793e77c71768a79cf
-  depends:
-  - libboost 1.84.0 hf763ba5_5
-  - libboost-headers 1.84.0 hce30654_5
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 39864
-  timestamp: 1722290608753
-- kind: conda
-  name: libboost-headers
-  version: 1.84.0
-  build: h57928b3_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.84.0-h57928b3_5.conda
-  sha256: 3ed7b049aaabff496edf85a9f10452eb24cd191bdf083881ec029bcc945dcfb1
-  md5: c86a120ddea5803b611849d7dd040bfc
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 13887896
-  timestamp: 1722291217938
-- kind: conda
-  name: libboost-headers
-  version: 1.84.0
-  build: h694c41f_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.84.0-h694c41f_5.conda
-  sha256: 15bce37e1d03857ddf4163e8ec41196031807bd2462d62e51e5170b6961a32d5
-  md5: cca25396a4f0265d60fbeae0b8fbbfcc
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 13829572
-  timestamp: 1722290114615
-- kind: conda
-  name: libboost-headers
-  version: 1.84.0
-  build: ha770c72_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.84.0-ha770c72_5.conda
-  sha256: 85257c026772e47054683aa466c358fbd229d54055f42126974a77d577b0192f
-  md5: 39d4e07ebb688d3d4b331e9b20389d05
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 13664568
-  timestamp: 1722289895857
-- kind: conda
-  name: libboost-headers
-  version: 1.84.0
-  build: hce30654_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-headers-1.84.0-hce30654_5.conda
-  sha256: 83743a443f2bc2876c50da4399550201d4e305f80dc898b541aeebe67e1bc76a
-  md5: 1456091337ca76984ae2b17f6cb0f67e
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 13818790
-  timestamp: 1722290480643
-- kind: conda
-  name: libboost-python
-  version: 1.84.0
-  build: py312h44e70fa_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-python-1.84.0-py312h44e70fa_5.conda
-  sha256: d243a8d2d5afa47d9d2a3bf47984466dac8958bf5dc10890ee6d670401258c54
-  md5: 7c8a3c02f353447da7d15ea89df1cb8a
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - py-boost <0.0a0
-  - boost =1.84.0
-  license: BSL-1.0
-  size: 108893
-  timestamp: 1722290878549
-- kind: conda
-  name: libboost-python
-  version: 1.84.0
-  build: py312hbaa7e33_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-python-1.84.0-py312hbaa7e33_5.conda
-  sha256: 907dfba63f9e8e3fbfb3c6b5b018c327b26bed13db8537ad2ee73c9b4319dfd4
-  md5: 85ce716981c6f23948c7aa21db336e54
-  depends:
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - py-boost <0.0a0
-  - boost =1.84.0
-  license: BSL-1.0
-  size: 114638
-  timestamp: 1722291673733
-- kind: conda
-  name: libboost-python
-  version: 1.84.0
-  build: py312hf74af30_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.84.0-py312hf74af30_5.conda
-  sha256: a4edc94962eda2f0185c3e61bada39bbf063dc562dfbfd46980bd3d8b24169f4
-  md5: 56712a4ad5e24124ce37d4a6bc2c0e94
+  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.84.0-hb8260a3_6.conda
+  sha256: f0863cc9af17a6bff5add1a882ed57cb8a135ad81578e96855a73cf2d0760a45
+  md5: 6d387a528d4d10a97c6def56fa32d5a1
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp =1.84.0
+  license: BSL-1.0
+  size: 2827751
+  timestamp: 1725325861944
+- kind: conda
+  name: libboost
+  version: 1.84.0
+  build: hbe88bda_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.84.0-hbe88bda_6.conda
+  sha256: f378a8495c17fff9e49cfacbde5ef279b37ae1249e2de590c5a8659fcecff442
+  md5: 177c21064cb0e48f58ff26d83ae09f80
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp =1.84.0
+  license: BSL-1.0
+  size: 2044745
+  timestamp: 1725326262243
+- kind: conda
+  name: libboost-devel
+  version: 1.84.0
+  build: h1a2810e_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.84.0-h1a2810e_6.conda
+  sha256: 5c4a4bd9f5313d752ab3877af94a368e5d93846589e68e5e3bc5b0b06dd1eadf
+  md5: b40ba5b4b8d5e9ce2538f3ce3a53a8d1
+  depends:
+  - libboost 1.84.0 hb8260a3_6
+  - libboost-headers 1.84.0 ha770c72_6
+  constrains:
+  - boost-cpp =1.84.0
+  license: BSL-1.0
+  size: 39340
+  timestamp: 1725325997681
+- kind: conda
+  name: libboost-devel
+  version: 1.84.0
+  build: h6a1c779_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-devel-1.84.0-h6a1c779_6.conda
+  sha256: 21ea489ea4d39639f96717fea55df15460a3fb58d6d87c3278a673102e40a624
+  md5: d3b2f809d86c12eb49fd0729735eb120
+  depends:
+  - libboost 1.84.0 hbe88bda_6
+  - libboost-headers 1.84.0 h694c41f_6
+  constrains:
+  - boost-cpp =1.84.0
+  license: BSL-1.0
+  size: 40021
+  timestamp: 1725326450004
+- kind: conda
+  name: libboost-devel
+  version: 1.84.0
+  build: h91493d7_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-devel-1.84.0-h91493d7_6.conda
+  sha256: 94dda6c8e021f969c31fd6b5dc3bcd866d8ff8fe2e392855dd3de212a83d6db5
+  md5: fb921ce99aa833e376bc81c9dacc546a
+  depends:
+  - libboost 1.84.0 h444863b_6
+  - libboost-headers 1.84.0 h57928b3_6
+  constrains:
+  - boost-cpp =1.84.0
+  license: BSL-1.0
+  size: 41760
+  timestamp: 1725327254977
+- kind: conda
+  name: libboost-devel
+  version: 1.84.0
+  build: hf450f58_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-devel-1.84.0-hf450f58_6.conda
+  sha256: d609dfed5ccf636954c068fb80d467655d5061baa65fe171357d3e2b6a007eb8
+  md5: b075e2676d605a1b03aa75d1b8d78b9f
+  depends:
+  - libboost 1.84.0 h29978a0_6
+  - libboost-headers 1.84.0 hce30654_6
+  constrains:
+  - boost-cpp =1.84.0
+  license: BSL-1.0
+  size: 39920
+  timestamp: 1725326866242
+- kind: conda
+  name: libboost-headers
+  version: 1.84.0
+  build: h57928b3_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.84.0-h57928b3_6.conda
+  sha256: 4e18b199d1be3d4e6869c9f64c04121d864c978577d777c695343b860a4769a6
+  md5: 0e25f30ac93be7d025058d0ac61bd2bc
+  constrains:
+  - boost-cpp =1.84.0
+  license: BSL-1.0
+  size: 13872845
+  timestamp: 1725327061252
+- kind: conda
+  name: libboost-headers
+  version: 1.84.0
+  build: h694c41f_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.84.0-h694c41f_6.conda
+  sha256: c93ca8b91b2afd5102e7963c8a4deb45c9ae196b2f9ade1909a996c2b4f60274
+  md5: 2c93e0c5fa315ce7e56d634170e19df2
+  constrains:
+  - boost-cpp =1.84.0
+  license: BSL-1.0
+  size: 13797783
+  timestamp: 1725326295716
+- kind: conda
+  name: libboost-headers
+  version: 1.84.0
+  build: ha770c72_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.84.0-ha770c72_6.conda
+  sha256: d9aaa8ccdb22a7cdeed760442d5de43d61516c7ff1331820fe5de990c53bdccf
+  md5: 902314c959b143be52386ccebe871f53
+  constrains:
+  - boost-cpp =1.84.0
+  license: BSL-1.0
+  size: 13678405
+  timestamp: 1725325883046
+- kind: conda
+  name: libboost-headers
+  version: 1.84.0
+  build: hce30654_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-headers-1.84.0-hce30654_6.conda
+  sha256: bb6d4f7356444c6836b1d1d9e0fb6e5046c626d8207183853909f5e4cf3ba533
+  md5: a3c527397efda7025f3ccfa37cdd64c2
+  constrains:
+  - boost-cpp =1.84.0
+  license: BSL-1.0
+  size: 13808237
+  timestamp: 1725326685890
+- kind: conda
+  name: libboost-python
+  version: 1.84.0
+  build: py312h082b758_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-python-1.84.0-py312h082b758_6.conda
+  sha256: 5ed643c0b1ecf35bb39de00dc70e92715238139c98adffff15ed9d9d9398ce85
+  md5: 8c9bbad63ede0104b0dda60801a448c4
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
   - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   constrains:
-  - boost =1.84.0
   - py-boost <0.0a0
+  - boost =1.84.0
   license: BSL-1.0
-  size: 124878
-  timestamp: 1722290442257
+  size: 108941
+  timestamp: 1725326767251
 - kind: conda
   name: libboost-python
   version: 1.84.0
-  build: py312hffe1f2a_5
-  build_number: 5
+  build: py312h707656b_6
+  build_number: 6
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-python-1.84.0-py312hffe1f2a_5.conda
-  sha256: 01e21d18ae0803d650b6a615848f45050a6509d05d45972eb2ebff66e7ca5b19
-  md5: 15d4fced533c7ed6f803068ecdb3661e
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-python-1.84.0-py312h707656b_6.conda
+  sha256: d8e3252b709d69cb084dff06bb40cb9cac11794bb904dcc606c6c4671bd68e9a
+  md5: dee064d435100acfe98efb03dabcbc0f
   depends:
   - __osx >=11.0
-  - libcxx >=16
+  - libcxx >=17
   - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
   constrains:
-  - py-boost <0.0a0
   - boost =1.84.0
-  license: BSL-1.0
-  size: 107880
-  timestamp: 1722291116845
-- kind: conda
-  name: libboost-python-devel
-  version: 1.84.0
-  build: py312h0be7463_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-python-devel-1.84.0-py312h0be7463_5.conda
-  sha256: 8db3e570287940ea80c1a8be22ec103de3cfff8d0eb2e28e9692d2a8ee3d9db8
-  md5: 2870d5689be0341e0a07ee9a5d66b1e6
-  depends:
-  - libboost-devel 1.84.0 h2b186f8_5
-  - libboost-python 1.84.0 py312h44e70fa_5
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
   - py-boost <0.0a0
-  - boost =1.84.0
   license: BSL-1.0
-  size: 20446
-  timestamp: 1722291075207
+  size: 107839
+  timestamp: 1725327328762
 - kind: conda
-  name: libboost-python-devel
+  name: libboost-python
   version: 1.84.0
-  build: py312h7e22eef_5
-  build_number: 5
+  build: py312hbaa7e33_6
+  build_number: 6
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-python-devel-1.84.0-py312h7e22eef_5.conda
-  sha256: e3aa8224a5518d5924f554cf1af61b4a7a71351eeaf51989fd25fb7ed9a3620b
-  md5: d27bd7afac3b2aa64f7cfaf2585e626b
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-python-1.84.0-py312hbaa7e33_6.conda
+  sha256: febaebadec2e9460f9465f1948df4747939e889563e1a59e873e41990aa64272
+  md5: a5359637242fbd16e346da210c3bac8d
   depends:
-  - libboost-devel 1.84.0 h91493d7_5
-  - libboost-python 1.84.0 py312hbaa7e33_5
   - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   constrains:
-  - py-boost <0.0a0
   - boost =1.84.0
+  - py-boost <0.0a0
   license: BSL-1.0
-  size: 20890
-  timestamp: 1722292684311
+  size: 114308
+  timestamp: 1725328290622
 - kind: conda
-  name: libboost-python-devel
+  name: libboost-python
   version: 1.84.0
-  build: py312h9cebb41_5
-  build_number: 5
+  build: py312hc39e661_6
+  build_number: 6
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-devel-1.84.0-py312h9cebb41_5.conda
-  sha256: e90fd7e07dc3ddb6b49d1e000a2445daf9c3d162c610e2c78f0cf808ee249b71
-  md5: 1e91f41ba0da28b255ceb4812d853157
+  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.84.0-py312hc39e661_6.conda
+  sha256: bdee7e7ead1457b63b211801b38de303a5d486f49db374a8464515bcaf219182
+  md5: a6002a7302d7522f246a452f0f50ce38
   depends:
-  - libboost-devel 1.84.0 h00ab1b0_5
-  - libboost-python 1.84.0 py312hf74af30_5
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   constrains:
-  - boost =1.84.0
   - py-boost <0.0a0
+  - boost =1.84.0
   license: BSL-1.0
-  size: 20221
-  timestamp: 1722290538514
+  size: 125230
+  timestamp: 1725326340279
 - kind: conda
   name: libboost-python-devel
   version: 1.84.0
-  build: py312ha814d7c_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-python-devel-1.84.0-py312ha814d7c_5.conda
-  sha256: 9479190209f86a2f1d2e3cdce120fe8bb2fc0d4c64ec1060defc5a1712301b56
-  md5: 32aacce7dc3b41ac585a4757d84b945c
+  build: py312h0be7463_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-python-devel-1.84.0-py312h0be7463_6.conda
+  sha256: 7a6503dc3d704c9e5102726a38730684aeb16ae87554f262955bd2f6a5a39386
+  md5: c51c7d39c6e3f2be15cd47c3fbff5b2e
   depends:
-  - libboost-devel 1.84.0 hf450f58_5
-  - libboost-python 1.84.0 py312hffe1f2a_5
+  - libboost-devel 1.84.0 h6a1c779_6
+  - libboost-python 1.84.0 py312h082b758_6
   - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -6131,251 +5835,268 @@ packages:
   - py-boost <0.0a0
   - boost =1.84.0
   license: BSL-1.0
-  size: 20508
-  timestamp: 1722291409677
+  size: 20428
+  timestamp: 1725327032093
 - kind: conda
-  name: libbrotlicommon
-  version: 1.1.0
-  build: h0dc2134_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
-  sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
-  md5: 9e6c31441c9aa24e41ace40d6151aab6
-  license: MIT
-  license_family: MIT
-  size: 67476
-  timestamp: 1695990207321
-- kind: conda
-  name: libbrotlicommon
-  version: 1.1.0
-  build: hb547adb_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
-  sha256: 556f0fddf4bd4d35febab404d98cb6862ce3b7ca843e393da0451bfc4654cf07
-  md5: cd68f024df0304be41d29a9088162b02
-  license: MIT
-  license_family: MIT
-  size: 68579
-  timestamp: 1695990426128
-- kind: conda
-  name: libbrotlicommon
-  version: 1.1.0
-  build: hcfcfb64_1
-  build_number: 1
+  name: libboost-python-devel
+  version: 1.84.0
+  build: py312h7e22eef_6
+  build_number: 6
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
-  sha256: f75fed29b0cc503d1b149a4945eaa32df56e19da5e2933de29e8f03947203709
-  md5: f77f319fb82980166569e1280d5b2864
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-python-devel-1.84.0-py312h7e22eef_6.conda
+  sha256: 5000b3fc3f5a14a3211a05c37f5f1b554c9432490a3ab37244977ac531a41a4b
+  md5: bd0bf2ae709be89b95da0db73c334e17
+  depends:
+  - libboost-devel 1.84.0 h91493d7_6
+  - libboost-python 1.84.0 py312hbaa7e33_6
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - boost =1.84.0
+  - py-boost <0.0a0
+  license: BSL-1.0
+  size: 20910
+  timestamp: 1725328799262
+- kind: conda
+  name: libboost-python-devel
+  version: 1.84.0
+  build: py312h9cebb41_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-devel-1.84.0-py312h9cebb41_6.conda
+  sha256: 095dc488aec127d68a0c26e7a028b8e7c183e6ee3420fcb62b519779855979a9
+  md5: a550134e5ffde184aa7529760c3accc9
+  depends:
+  - libboost-devel 1.84.0 h1a2810e_6
+  - libboost-python 1.84.0 py312hc39e661_6
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - py-boost <0.0a0
+  - boost =1.84.0
+  license: BSL-1.0
+  size: 20337
+  timestamp: 1725326486143
+- kind: conda
+  name: libboost-python-devel
+  version: 1.84.0
+  build: py312ha814d7c_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-python-devel-1.84.0-py312ha814d7c_6.conda
+  sha256: c880ea47dc3158a3cf901825e9e9bec448284ae3c187fcfadc0ff428d02596f0
+  md5: e188e87c1491036aca0d3756e73fc1f8
+  depends:
+  - libboost-devel 1.84.0 hf450f58_6
+  - libboost-python 1.84.0 py312h707656b_6
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - boost =1.84.0
+  - py-boost <0.0a0
+  license: BSL-1.0
+  size: 20542
+  timestamp: 1725327732683
+- kind: conda
+  name: libbrotlicommon
+  version: 1.1.0
+  build: h00291cd_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+  sha256: b377056470a9fb4a100aa3c51b3581aab6496ba84d21cd99bcc1d5ef0359b1b6
+  md5: 58f2c4bdd56c46cc7451596e4ae68e0b
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 67267
+  timestamp: 1725267768667
+- kind: conda
+  name: libbrotlicommon
+  version: 1.1.0
+  build: h2466b09_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+  sha256: 33e8851c6cc8e2d93059792cd65445bfe6be47e4782f826f01593898ec95764c
+  md5: f7dc9a8f21d74eab46456df301da2972
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 70598
-  timestamp: 1695990405143
+  size: 70526
+  timestamp: 1725268159739
 - kind: conda
   name: libbrotlicommon
   version: 1.1.0
-  build: hd590300_1
-  build_number: 1
+  build: hb9d3cd8_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
-  sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
-  md5: aec6c91c7371c26392a06708a73c70e5
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+  sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
+  md5: 41b599ed2b02abcfdd84302bff174b23
   depends:
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 69403
-  timestamp: 1695990007212
+  size: 68851
+  timestamp: 1725267660471
 - kind: conda
-  name: libbrotlidec
+  name: libbrotlicommon
   version: 1.1.0
-  build: h0dc2134_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
-  sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
-  md5: 9ee0bab91b2ca579e10353738be36063
-  depends:
-  - libbrotlicommon 1.1.0 h0dc2134_1
-  license: MIT
-  license_family: MIT
-  size: 30327
-  timestamp: 1695990232422
-- kind: conda
-  name: libbrotlidec
-  version: 1.1.0
-  build: hb547adb_1
-  build_number: 1
+  build: hd74edd7_2
+  build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
-  sha256: c1c85937828ad3bc434ac60b7bcbde376f4d2ea4ee42d15d369bf2a591775b4a
-  md5: ee1a519335cc10d0ec7e097602058c0a
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+  sha256: 839dacb741bdbb25e58f42088a2001b649f4f12195aeb700b5ddfca3267749e5
+  md5: d0bf1dff146b799b319ea0434b93f779
   depends:
-  - libbrotlicommon 1.1.0 hb547adb_1
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 28928
-  timestamp: 1695990463780
+  size: 68426
+  timestamp: 1725267943211
 - kind: conda
   name: libbrotlidec
   version: 1.1.0
-  build: hcfcfb64_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
-  sha256: 1b352ee05931ea24c11cd4a994d673890fd1cc690c21e023e736bdaac2632e93
-  md5: 19ce3e1dacc7912b3d6ff40690ba9ae0
+  build: h00291cd_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+  sha256: 4d49ea72e2f44d2d7a8be5472e4bd0bc2c6b89c55569de2c43576363a0685c0c
+  md5: 34709a1f5df44e054c4a12ab536c5459
   depends:
-  - libbrotlicommon 1.1.0 hcfcfb64_1
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 29872
+  timestamp: 1725267807289
+- kind: conda
+  name: libbrotlidec
+  version: 1.1.0
+  build: h2466b09_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+  sha256: 234fc92f4c4f1cf22f6464b2b15bfc872fa583c74bf3ab9539ff38892c43612f
+  md5: 9bae75ce723fa34e98e239d21d752a7e
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 32788
-  timestamp: 1695990443165
+  size: 32685
+  timestamp: 1725268208844
 - kind: conda
   name: libbrotlidec
   version: 1.1.0
-  build: hd590300_1
-  build_number: 1
+  build: hb9d3cd8_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
-  sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
-  md5: f07002e225d7a60a694d42a7bf5ff53f
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+  sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
+  md5: 9566f0bd264fbd463002e759b8a82401
   depends:
-  - libbrotlicommon 1.1.0 hd590300_1
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 32775
-  timestamp: 1695990022788
+  size: 32696
+  timestamp: 1725267669305
 - kind: conda
-  name: libbrotlienc
+  name: libbrotlidec
   version: 1.1.0
-  build: h0dc2134_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
-  sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
-  md5: 8a421fe09c6187f0eb5e2338a8a8be6d
-  depends:
-  - libbrotlicommon 1.1.0 h0dc2134_1
-  license: MIT
-  license_family: MIT
-  size: 299092
-  timestamp: 1695990259225
-- kind: conda
-  name: libbrotlienc
-  version: 1.1.0
-  build: hb547adb_1
-  build_number: 1
+  build: hd74edd7_2
+  build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
-  sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
-  md5: d7e077f326a98b2cc60087eaff7c730b
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+  sha256: 6c6862eb274f21a7c0b60e5345467a12e6dda8b9af4438c66d496a2c1a538264
+  md5: 55e66e68ce55523a6811633dd1ac74e2
   depends:
-  - libbrotlicommon 1.1.0 hb547adb_1
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
   license: MIT
   license_family: MIT
-  size: 280943
-  timestamp: 1695990509392
+  size: 28378
+  timestamp: 1725267980316
 - kind: conda
   name: libbrotlienc
   version: 1.1.0
-  build: hcfcfb64_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
-  sha256: eae6b76154e594c6d211160c6d1aeed848672618152a562e0eabdfa641d34aca
-  md5: 71e890a0b361fd58743a13f77e1506b7
+  build: h00291cd_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+  sha256: 477d236d389473413a1ccd2bec1b66b2f1d2d7d1b4a57bb56421b7b611a56cd1
+  md5: 691f0dcb36f1ae67f5c489f20ae987ea
   depends:
-  - libbrotlicommon 1.1.0 hcfcfb64_1
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 296353
+  timestamp: 1725267822076
+- kind: conda
+  name: libbrotlienc
+  version: 1.1.0
+  build: h2466b09_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+  sha256: 3d0dd7ef505962f107b7ea8f894e0b3dd01bf46852b362c8a7fc136b039bc9e1
+  md5: 85741a24d97954a991e55e34bc55990b
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 246515
-  timestamp: 1695990479484
+  size: 245929
+  timestamp: 1725268238259
 - kind: conda
   name: libbrotlienc
   version: 1.1.0
-  build: hd590300_1
-  build_number: 1
+  build: hb9d3cd8_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
-  sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
-  md5: 5fc11c6020d421960607d821310fcd4d
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+  sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
+  md5: 06f70867945ea6a84d35836af780f1de
   depends:
-  - libbrotlicommon 1.1.0 hd590300_1
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 282523
-  timestamp: 1695990038302
+  size: 281750
+  timestamp: 1725267679782
 - kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 22_osx64_openblas
-  build_number: 22
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-22_osx64_openblas.conda
-  sha256: 6a2ba9198e2320c3e22fe3d121310cf8a8ac663e94100c5693b34523fcb3cc04
-  md5: b9fef82772330f61b2b0201c72d2c29b
-  depends:
-  - libblas 3.9.0 22_osx64_openblas
-  constrains:
-  - liblapacke 3.9.0 22_osx64_openblas
-  - blas * openblas
-  - liblapack 3.9.0 22_osx64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14636
-  timestamp: 1712542311437
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 23_linux64_openblas
-  build_number: 23
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-23_linux64_openblas.conda
-  sha256: 3e7a3236e7e03e308e1667d91d0aa70edd0cba96b4b5563ef4adde088e0881a5
-  md5: eede29b40efa878cbe5bdcb767e97310
-  depends:
-  - libblas 3.9.0 23_linux64_openblas
-  constrains:
-  - liblapacke 3.9.0 23_linux64_openblas
-  - liblapack 3.9.0 23_linux64_openblas
-  - blas * openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14798
-  timestamp: 1721688767584
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 23_osxarm64_openblas
-  build_number: 23
+  name: libbrotlienc
+  version: 1.1.0
+  build: hd74edd7_2
+  build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-23_osxarm64_openblas.conda
-  sha256: c39d944909d0608bd0333398be5e0051045c9451bfd6cc6320732d33375569c8
-  md5: bad6ee9b7d5584efc2bc5266137b5f0d
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+  sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
+  md5: 4f3a434504c67b2c42565c0b85c1885c
   depends:
-  - libblas 3.9.0 23_osxarm64_openblas
-  constrains:
-  - liblapack 3.9.0 23_osxarm64_openblas
-  - liblapacke 3.9.0 23_osxarm64_openblas
-  - blas * openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14991
-  timestamp: 1721689017803
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 279644
+  timestamp: 1725268003553
 - kind: conda
   name: libcblas
   version: 3.9.0
@@ -6395,6 +6116,63 @@ packages:
   license_family: BSD
   size: 5191981
   timestamp: 1721689628480
+- kind: conda
+  name: libcblas
+  version: 3.9.0
+  build: 24_linux64_openblas
+  build_number: 24
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-24_linux64_openblas.conda
+  sha256: 2a52bccc5b03cdf014d856d0b85dbd591faa335ab337d620cd6aded121d7153c
+  md5: f5b8822297c9c790cec0795ca1fc9be6
+  depends:
+  - libblas 3.9.0 24_linux64_openblas
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 24_linux64_openblas
+  - liblapacke 3.9.0 24_linux64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14910
+  timestamp: 1726668461033
+- kind: conda
+  name: libcblas
+  version: 3.9.0
+  build: 24_osx64_blis
+  build_number: 24
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-24_osx64_blis.conda
+  sha256: a4f043716bc2c64f5076079314176c19b668eea398c881b9449a97b5edb2baa5
+  md5: ab4fd8dd5d8bdf50e35e487cdbaf19e2
+  depends:
+  - libblas 3.9.0 24_osx64_blis
+  constrains:
+  - blas * blis
+  track_features:
+  - blas_blis
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15011
+  timestamp: 1726668633090
+- kind: conda
+  name: libcblas
+  version: 3.9.0
+  build: 24_osxarm64_openblas
+  build_number: 24
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-24_osxarm64_openblas.conda
+  sha256: 40dc3f7c44af5cd5a2020386cb30f92943a9d8f7f54321b4d6ae32b2e54af9a4
+  md5: c8977086a19233153e454bb2b332a920
+  depends:
+  - libblas 3.9.0 24_osxarm64_openblas
+  constrains:
+  - liblapack 3.9.0 24_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 24_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15062
+  timestamp: 1726668809379
 - kind: conda
   name: libclang-cpp16
   version: 16.0.6
@@ -6432,57 +6210,55 @@ packages:
 - kind: conda
   name: libclang-cpp18.1
   version: 18.1.8
-  build: default_h0c94c6a_3
-  build_number: 3
+  build: default_h0c94c6a_5
+  build_number: 5
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp18.1-18.1.8-default_h0c94c6a_3.conda
-  sha256: f6f748c4e138f7a95cbd5adb73f9be0f6c2ce76112c3c0dfbf172adf2113960e
-  md5: 0fc68656ac9fd288124eea5598a778b9
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp18.1-18.1.8-default_h0c94c6a_5.conda
+  sha256: 1f83e81b6328e973767e0d0e9aa7b6486a57f09bdfc4d4b78261dda3badaa2bf
+  md5: a03d49b4f1b1a9d8904f5ee7cc715967
   depends:
   - __osx >=10.13
-  - libcxx >=16
+  - libcxx >=18.1.8
   - libllvm18 >=18.1.8,<18.2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 13751731
-  timestamp: 1724893444037
+  size: 13657261
+  timestamp: 1726904353048
 - kind: conda
   name: libclang-cpp18.1
   version: 18.1.8
-  build: default_h5c12605_3
-  build_number: 3
+  build: default_h5c12605_5
+  build_number: 5
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp18.1-18.1.8-default_h5c12605_3.conda
-  sha256: dc24ff5727bfd880c2f45d7e273aee4561f9b17484c274820eaa36610f4481bd
-  md5: 1f121df36049646304545b416df28cf5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp18.1-18.1.8-default_h5c12605_5.conda
+  sha256: c82a0b618debf0bac5c7f66c47ba6f7b726acd831daf8d1a72061c3e9b9969c5
+  md5: 871576a2d3e0c8c3d0278e1085e74914
   depends:
   - __osx >=11.0
-  - libcxx >=16
+  - libcxx >=18.1.8
   - libllvm18 >=18.1.8,<18.2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 12871967
-  timestamp: 1724893261506
+  size: 12775616
+  timestamp: 1726862192152
 - kind: conda
   name: libclang-cpp18.1
   version: 18.1.8
-  build: default_hf981a13_3
-  build_number: 3
+  build: default_hf981a13_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp18.1-18.1.8-default_hf981a13_3.conda
-  sha256: 90d87664402d74dd8c81b1f5901e027ac386a9f3a4c32a703f07b2f29fada50b
-  md5: bc7284193bc95c2cf8a77d5a2c555b75
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp18.1-18.1.8-default_hf981a13_5.conda
+  sha256: ffcd09fe3e346fe33abaeb02fd07679310ffab7d35c837ef7c553431f3cdb94b
+  md5: f9b854fee7cc67a4cd27a930926344f1
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc
-  - libgcc-ng >=12
+  - libgcc >=12
   - libllvm18 >=18.1.8,<18.2.0a0
-  - libstdcxx
-  - libstdcxx-ng >=12
+  - libstdcxx >=12
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 19176369
-  timestamp: 1724894002190
+  size: 19176405
+  timestamp: 1726866675823
 - kind: conda
   name: libcrc32c
   version: 1.1.2
@@ -6541,81 +6317,6 @@ packages:
   license_family: BSD
   size: 20128
   timestamp: 1633683906221
-- kind: conda
-  name: libcublas
-  version: 12.4.2.65
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcublas-12.4.2.65-0.tar.bz2
-  sha256: 352fc593ed8f724d15d344b3067c4b7c95e18f117fe0a04b0cfc6129a042f952
-  md5: 60e467cedbe572a70d1784a3750d776b
-  size: 35161
-  timestamp: 1709090617680
-- kind: conda
-  name: libcublas-dev
-  version: 12.4.2.65
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcublas-dev-12.4.2.65-0.tar.bz2
-  sha256: ff1828006c7453bcab5c3542f81f11f1f722acc6f9d8fba077fc58fdc11c07ff
-  md5: 8fbfc7027b91d176cc74eb383b722b33
-  depends:
-  - libcublas >=12.4.2.65
-  size: 360950325
-  timestamp: 1709090817468
-- kind: conda
-  name: libcufft
-  version: 11.2.0.44
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcufft-11.2.0.44-0.tar.bz2
-  sha256: e57b16ba9aa84e9fb594774adeb78856a6db2de6a7b4f7617d9f74f75fcde069
-  md5: abdcc463b5f62ed83ac0931e7a6212ea
-  size: 6106
-  timestamp: 1709091181276
-- kind: conda
-  name: libcufft-dev
-  version: 11.2.0.44
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcufft-dev-11.2.0.44-0.tar.bz2
-  sha256: aa533e08bb4f965e2417f2048e0b3cc4489c128c2175c9b8174a1333dfe25397
-  md5: 24d7c73bcb1c0c3dcfa677137eecff4e
-  depends:
-  - libcufft >=11.2.0.44
-  size: 198752233
-  timestamp: 1709091314085
-- kind: conda
-  name: libcurand
-  version: 10.3.7.68
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcurand-10.3.7.68-0.tar.bz2
-  sha256: c0ee97cd8bbc92e17bef4e8903cd3969ce718ebb5d6341fefaae9792c63a177d
-  md5: 554d1475a65c48efde1ee1fce14ce8a9
-  depends:
-  - cuda-version >=12.6,<12.7.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 51698147
-  timestamp: 1723662114118
-- kind: conda
-  name: libcurand-dev
-  version: 10.3.7.68
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcurand-dev-10.3.7.68-0.tar.bz2
-  sha256: 26a756703f15fdfb7d2696d2ea59e3067bfcb47483e32a5c5cae895fc92ea163
-  md5: 70d2a21e00b42d249ff012a7b3adc149
-  depends:
-  - cuda-version >=12.6,<12.7.0a0
-  - libcurand 10.3.7.68 0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 384627
-  timestamp: 1723662140300
 - kind: conda
   name: libcurl
   version: 8.7.1
@@ -6694,79 +6395,33 @@ packages:
   size: 334903
   timestamp: 1716379079949
 - kind: conda
-  name: libcusolver
-  version: 11.6.0.99
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcusolver-11.6.0.99-0.tar.bz2
-  sha256: c06d06082153d9ac78b5c859012a24da2e7f2e029756c5e88138bedd83c92bb0
-  md5: ce775d9e3426af46e54c876d86e20c63
-  size: 29820
-  timestamp: 1709092005706
-- kind: conda
-  name: libcusolver-dev
-  version: 11.6.0.99
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcusolver-dev-11.6.0.99-0.tar.bz2
-  sha256: c9d60d69376955752c600ce14248729072ae4d0285050842250fab2139cbc5d6
-  md5: c1c9fd025fc3a1d85b4c1a26698bcb6b
-  depends:
-  - libcusolver >=11.6.0.99
-  size: 117489124
-  timestamp: 1709092069405
-- kind: conda
-  name: libcusparse
-  version: 12.3.0.142
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcusparse-12.3.0.142-0.tar.bz2
-  sha256: 1750447d7d07952a4e42aea974a21ef7b151cdfa312695de877ea6736e38ea34
-  md5: c389e6cddd4371cbae5dde4d703b9a1b
-  size: 13119
-  timestamp: 1709090448272
-- kind: conda
-  name: libcusparse-dev
-  version: 12.3.0.142
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcusparse-dev-12.3.0.142-0.tar.bz2
-  sha256: 23720e27f8eccf589fc4e62f9775543d1df8418faa314593b6112e531bf25463
-  md5: f3b19cde253c7cde193b351cb1c01dcc
-  depends:
-  - libcusparse >=12.3.0.142
-  size: 184498999
-  timestamp: 1709090590858
-- kind: conda
   name: libcxx
-  version: 18.1.8
-  build: h3ed4263_6
-  build_number: 6
+  version: 19.1.0
+  build: ha82da77_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-18.1.8-h3ed4263_6.conda
-  sha256: 6e267698e575bb02c8ed86184fad6d6d3504643dcfa10dad0306d3d25a3d22e3
-  md5: 9fefa1597c93b710cc9bce87bffb0428
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.0-ha82da77_0.conda
+  sha256: b71167d9b7c8e598b12bbdafefd0139e3c70c6eb258cbda3de3fb422d0098025
+  md5: a4c66c0d5b0f268fd27a956145004d27
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 1216771
-  timestamp: 1724726498879
+  size: 520766
+  timestamp: 1726782571130
 - kind: conda
   name: libcxx
-  version: 18.1.8
-  build: hd876a4e_6
-  build_number: 6
+  version: 19.1.0
+  build: hf95d169_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-hd876a4e_6.conda
-  sha256: 17f9d82da076bee9db33272f43e04be98afbcb27eba7cd83dda3212a7ee1c218
-  md5: 93efb2350f312a3c871e87d9fdc09813
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.0-hf95d169_0.conda
+  sha256: 81e6bdf19cf202d769509d116c92046d164c23c91b6f791f439d10f3812629c9
+  md5: 0ed117b4cbbf7917dd47b4390e511d2a
   depends:
   - __osx >=10.13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 1223212
-  timestamp: 1724726420315
+  size: 528123
+  timestamp: 1726815971547
 - kind: conda
   name: libcxx-devel
   version: 16.0.6
@@ -7009,62 +6664,71 @@ packages:
   timestamp: 1685725977222
 - kind: conda
   name: libexpat
-  version: 2.6.2
-  build: h59595ed_0
+  version: 2.6.3
+  build: h5888daf_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
-  sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
-  md5: e7ba12deb7020dd080c6c70e7b6f6a3d
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
+  sha256: 4bb47bb2cd09898737a5211e2992d63c555d63715a07ba56eae0aff31fb89c22
+  md5: 59f4c43bb1b5ef1c71946ff2cbf59524
   depends:
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   constrains:
-  - expat 2.6.2.*
+  - expat 2.6.3.*
   license: MIT
   license_family: MIT
-  size: 73730
-  timestamp: 1710362120304
+  size: 73616
+  timestamp: 1725568742634
 - kind: conda
   name: libexpat
-  version: 2.6.2
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
-  sha256: 79f612f75108f3e16bbdc127d4885bb74729cf66a8702fca0373dad89d40c4b7
-  md5: bc592d03f62779511d392c175dcece64
-  constrains:
-  - expat 2.6.2.*
-  license: MIT
-  license_family: MIT
-  size: 139224
-  timestamp: 1710362609641
-- kind: conda
-  name: libexpat
-  version: 2.6.2
-  build: h73e2aa4_0
+  version: 2.6.3
+  build: hac325c4_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
-  sha256: a188a77b275d61159a32ab547f7d17892226e7dac4518d2c6ac3ac8fc8dfde92
-  md5: 3d1d51c8f716d97c864d12f7af329526
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.3-hac325c4_0.conda
+  sha256: dd22dffad6731c352f4c14603868c9cce4d3b50ff5ff1e50f416a82dcb491947
+  md5: c1db99b0a94a2f23bd6ce39e2d314e07
+  depends:
+  - __osx >=10.13
   constrains:
-  - expat 2.6.2.*
+  - expat 2.6.3.*
   license: MIT
   license_family: MIT
-  size: 69246
-  timestamp: 1710362566073
+  size: 70517
+  timestamp: 1725568864316
 - kind: conda
   name: libexpat
-  version: 2.6.2
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
-  sha256: ba7173ac30064ea901a4c9fb5a51846dcc25512ceb565759be7d18cbf3e5415e
-  md5: e3cde7cfa87f82f7cb13d482d5e0ad09
+  version: 2.6.3
+  build: he0c23c2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.3-he0c23c2_0.conda
+  sha256: 9543965d155b8da96fc67dd81705fe5c2571c7c00becc8de5534c850393d4e3c
+  md5: 21415fbf4d0de6767a621160b43e5dea
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   constrains:
-  - expat 2.6.2.*
+  - expat 2.6.3.*
   license: MIT
   license_family: MIT
-  size: 63655
-  timestamp: 1710362424980
+  size: 138992
+  timestamp: 1725569106114
+- kind: conda
+  name: libexpat
+  version: 2.6.3
+  build: hf9b8971_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
+  sha256: 5cbe5a199fba14ade55457a468ce663aac0b54832c39aa54470b3889b4c75c4a
+  md5: 5f22f07c2ab2dea8c66fe9585a062c96
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.3.*
+  license: MIT
+  license_family: MIT
+  size: 63895
+  timestamp: 1725568783033
 - kind: conda
   name: libffi
   version: 3.4.2
@@ -7790,63 +7454,6 @@ packages:
 - kind: conda
   name: liblapack
   version: 3.9.0
-  build: 22_osx64_openblas
-  build_number: 22
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-22_osx64_openblas.conda
-  sha256: e36744f3e780564d6748b5dd05e15ad6a1af9184cf32ab9d1304c13a6bc3e16b
-  md5: f21b282ff7ba14df6134a0fe6ab42b1b
-  depends:
-  - libblas 3.9.0 22_osx64_openblas
-  constrains:
-  - liblapacke 3.9.0 22_osx64_openblas
-  - blas * openblas
-  - libcblas 3.9.0 22_osx64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14657
-  timestamp: 1712542322711
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 23_linux64_openblas
-  build_number: 23
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-23_linux64_openblas.conda
-  sha256: 25c7aef86c8a1d9db0e8ee61aa7462ba3b46b482027a65d66eb83e3e6f949043
-  md5: 2af0879961951987e464722fd00ec1e0
-  depends:
-  - libblas 3.9.0 23_linux64_openblas
-  constrains:
-  - liblapacke 3.9.0 23_linux64_openblas
-  - libcblas 3.9.0 23_linux64_openblas
-  - blas * openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14823
-  timestamp: 1721688775172
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 23_osxarm64_openblas
-  build_number: 23
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-23_osxarm64_openblas.conda
-  sha256: 13799a137ffc80786725e7e2820d37d4c0d59dbb76013a14c21771415b0a4263
-  md5: 754ef44f72ab80fd14eaa789ac393a27
-  depends:
-  - libblas 3.9.0 23_osxarm64_openblas
-  constrains:
-  - blas * openblas
-  - liblapacke 3.9.0 23_osxarm64_openblas
-  - libcblas 3.9.0 23_osxarm64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14999
-  timestamp: 1721689026268
-- kind: conda
-  name: liblapack
-  version: 3.9.0
   build: 23_win64_mkl
   build_number: 23
   subdir: win-64
@@ -7864,62 +7471,63 @@ packages:
   size: 5191980
   timestamp: 1721689666180
 - kind: conda
-  name: liblapacke
+  name: liblapack
   version: 3.9.0
-  build: 22_osx64_openblas
-  build_number: 22
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-22_osx64_openblas.conda
-  sha256: 85309564345d8d7648d4bcb26715004128c2d8c90d6635666ff806b7a3ba8295
-  md5: 97be1e168d6657643c9e89fc5dd1fc6d
-  depends:
-  - libblas 3.9.0 22_osx64_openblas
-  - libcblas 3.9.0 22_osx64_openblas
-  - liblapack 3.9.0 22_osx64_openblas
-  constrains:
-  - blas * openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14654
-  timestamp: 1712542334599
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 23_linux64_openblas
-  build_number: 23
+  build: 24_linux64_openblas
+  build_number: 24
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-23_linux64_openblas.conda
-  sha256: 071384c9023997abc53111ec4dd71c27d68cb355b0a5c684f7cb7ba90a5ae830
-  md5: 89d7bcdb1e9a72a73e36d8e29d2a2beb
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-24_linux64_openblas.conda
+  sha256: a15da20c3c0fb5f356e5b4e2f1e87b0da11b9a46805a7f2609bf30f23453831a
+  md5: fd540578678aefe025705f4b58b36b2e
   depends:
-  - libblas 3.9.0 23_linux64_openblas
-  - libcblas 3.9.0 23_linux64_openblas
-  - liblapack 3.9.0 23_linux64_openblas
+  - libblas 3.9.0 24_linux64_openblas
   constrains:
   - blas * openblas
+  - libcblas 3.9.0 24_linux64_openblas
+  - liblapacke 3.9.0 24_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14831
-  timestamp: 1721688782834
+  size: 14911
+  timestamp: 1726668467187
 - kind: conda
-  name: liblapacke
+  name: liblapack
   version: 3.9.0
-  build: 23_osxarm64_openblas
-  build_number: 23
+  build: 24_osxarm64_openblas
+  build_number: 24
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-23_osxarm64_openblas.conda
-  sha256: 22444840b0fb88db268dd526e2852eabf0c025718e3550056b1eb47d68ab1afd
-  md5: 9f9411f6b0296f39737433efe99ba1a2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-24_osxarm64_openblas.conda
+  sha256: 67fbfd0466eee443cda9596ed22daabedc96b7b4d1b31f49b1c1b0983dd1dd2c
+  md5: 49a3241f76cdbe705e346204a328f66c
   depends:
-  - libblas 3.9.0 23_osxarm64_openblas
-  - libcblas 3.9.0 23_osxarm64_openblas
-  - liblapack 3.9.0 23_osxarm64_openblas
+  - libblas 3.9.0 24_osxarm64_openblas
   constrains:
   - blas * openblas
+  - liblapacke 3.9.0 24_osxarm64_openblas
+  - libcblas 3.9.0 24_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14963
-  timestamp: 1721689034740
+  size: 15063
+  timestamp: 1726668815824
+- kind: conda
+  name: liblapack
+  version: 3.9.0
+  build: 7_ha55dbfc_netlib
+  build_number: 7
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-7_ha55dbfc_netlib.conda
+  sha256: abb52d1b3bbad4ce34e6226ba36c322f61b22ce814b579da27676346f7259d7a
+  md5: 6e5590bbee8d73deb15d443ff23caf42
+  depends:
+  - __osx >=10.13
+  - libblas 3.9.0.*
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  track_features:
+  - blas_netlib blas_netlib_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2611459
+  timestamp: 1726579466075
 - kind: conda
   name: liblapacke
   version: 3.9.0
@@ -7939,6 +7547,66 @@ packages:
   license_family: BSD
   size: 5191961
   timestamp: 1721689704552
+- kind: conda
+  name: liblapacke
+  version: 3.9.0
+  build: 24_linux64_openblas
+  build_number: 24
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-24_linux64_openblas.conda
+  sha256: fdbdbdd2502de3c5eabe9d33bad0b504ddd1a374d6eaf440506cd61e1eb2f173
+  md5: 6db5d87ee60d6c7b5e64d18862a233d5
+  depends:
+  - libblas 3.9.0 24_linux64_openblas
+  - libcblas 3.9.0 24_linux64_openblas
+  - liblapack 3.9.0 24_linux64_openblas
+  constrains:
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14948
+  timestamp: 1726668473393
+- kind: conda
+  name: liblapacke
+  version: 3.9.0
+  build: 24_osxarm64_openblas
+  build_number: 24
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-24_osxarm64_openblas.conda
+  sha256: f8f462e72ed7f506a01c05ed552cc1b96a781861bf2961a1e67925bff9ae3f9a
+  md5: bb43697527f0b93d9f2f793a68f6b4ac
+  depends:
+  - libblas 3.9.0 24_osxarm64_openblas
+  - libcblas 3.9.0 24_osxarm64_openblas
+  - liblapack 3.9.0 24_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15077
+  timestamp: 1726668822406
+- kind: conda
+  name: liblapacke
+  version: 3.9.0
+  build: 7_ha55dbfc_netlib
+  build_number: 7
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-7_ha55dbfc_netlib.conda
+  sha256: 6c29db197f284798aeef7ff00f09d90d1b8fff72de388995602fda03b026c5f2
+  md5: b30551a61515f065eead7c04bfb13c7f
+  depends:
+  - __osx >=10.13
+  - libblas 3.9.0.*
+  - libcblas 3.9.0.*
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - liblapack 3.9.0.*
+  track_features:
+  - blas_netlib blas_netlib_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 359374
+  timestamp: 1726579490649
 - kind: conda
   name: libllvm16
   version: 16.0.6
@@ -8131,28 +7799,6 @@ packages:
   size: 734296
   timestamp: 1721460768363
 - kind: conda
-  name: libnpp
-  version: 12.2.5.2
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnpp-12.2.5.2-0.tar.bz2
-  sha256: ce8dada100665ffbecb8514ae66651c9ee03eaa5e7bbe2b79a98a18ffbd48514
-  md5: ac922adf6263b97d392bb0c706a22dfa
-  size: 317616
-  timestamp: 1709091294889
-- kind: conda
-  name: libnpp-dev
-  version: 12.2.5.2
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnpp-dev-12.2.5.2-0.tar.bz2
-  sha256: fc92bce66d00910a44a7707f7feb4e2dfb735fb68fdea8505e8fddd039c01c38
-  md5: 11ca736a47c2b4d86253b37c8a188c48
-  depends:
-  - libnpp >=12.2.5.2
-  size: 145968928
-  timestamp: 1709091426810
-- kind: conda
   name: libnsl
   version: 2.0.1
   build: hd590300_0
@@ -8166,83 +7812,6 @@ packages:
   license_family: GPL
   size: 33408
   timestamp: 1697359010159
-- kind: conda
-  name: libnvfatbin
-  version: 12.6.68
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnvfatbin-12.6.68-0.tar.bz2
-  sha256: 312e97990b1094973495baf5452ce74cf391ac578f6b915eb0a2997d6951cd06
-  md5: 48b2a8cd2c1f7d49269e4ae805f85a7d
-  depends:
-  - cuda-version >=12.6,<12.7.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 384447
-  timestamp: 1723661633470
-- kind: conda
-  name: libnvfatbin-dev
-  version: 12.6.68
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnvfatbin-dev-12.6.68-0.tar.bz2
-  sha256: ac6bf636be18e0afdaaafb4e2051903d7cb9882accbb1e7b2950c68f7efa9d0e
-  md5: 90115c76ebf62a0cbbc90b701d901699
-  depends:
-  - cuda-version >=12.6,<12.7.0a0
-  - libnvfatbin 12.6.68 0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  constrains:
-  - liblibnvfatbin-static >=12.6.68
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1691163
-  timestamp: 1723661643540
-- kind: conda
-  name: libnvjitlink
-  version: 12.4.99
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnvjitlink-12.4.99-0.tar.bz2
-  sha256: 7ebc52c6431ac4b08abde103e0a6db39f80bd840db908ea43aef90cbd00bc836
-  md5: e7e58393bbe72453fe668a9223d5ae02
-  size: 75273871
-  timestamp: 1709090800435
-- kind: conda
-  name: libnvjitlink-dev
-  version: 12.4.99
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnvjitlink-dev-12.4.99-0.tar.bz2
-  sha256: 2a393713b2888a017734fcd61a40bdbb2653d106a1fd282c54bee2df29601f92
-  md5: cbcd3fe51cd24137c0ffe490e05a2177
-  depends:
-  - libnvjitlink >=12.4.99
-  size: 14991520
-  timestamp: 1709090938959
-- kind: conda
-  name: libnvjpeg
-  version: 12.3.1.89
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-12.3.1.89-0.tar.bz2
-  sha256: ee991d870fa643f69cd998d55ade0e62dadf5956dc74ad36c605ea4cdb7ad9fe
-  md5: 3b7951b325def4cdf046647fe24b4366
-  size: 5081
-  timestamp: 1709090617516
-- kind: conda
-  name: libnvjpeg-dev
-  version: 12.3.1.89
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-dev-12.3.1.89-0.tar.bz2
-  sha256: 01c8912aa444d9520c51a40b34ecf8b3cd1949bc813b01ac0d2d8b09b5a25856
-  md5: 562bc3ba254943f2ef55d63d385b0650
-  depends:
-  - libnvjpeg >=12.3.1.89
-  size: 2620481
-  timestamp: 1709090632405
 - kind: conda
   name: libopenblas
   version: 0.3.27
@@ -8263,26 +7832,6 @@ packages:
   license_family: BSD
   size: 2925328
   timestamp: 1720425811743
-- kind: conda
-  name: libopenblas
-  version: 0.3.27
-  build: openmp_h8869122_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_h8869122_1.conda
-  sha256: 83b0b9d3d09889b3648a81d2c18a2d78c405b03b115107941f0496a8b358ce6d
-  md5: c0798ad76ddd730dade6ff4dff66e0b5
-  depends:
-  - __osx >=10.13
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - llvm-openmp >=16.0.6
-  constrains:
-  - openblas >=0.3.27,<0.3.28.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6047513
-  timestamp: 1720426759731
 - kind: conda
   name: libopenblas
   version: 0.3.27
@@ -8382,60 +7931,63 @@ packages:
   timestamp: 1714448276294
 - kind: conda
   name: libpng
-  version: 1.6.43
-  build: h091b4b1_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
-  sha256: 66c4713b07408398f2221229a1c1d5df57d65dc0902258113f2d9ecac4772495
-  md5: 77e684ca58d82cae9deebafb95b1a2b8
-  depends:
-  - libzlib >=1.2.13,<2.0.0a0
-  license: zlib-acknowledgement
-  size: 264177
-  timestamp: 1708780447187
-- kind: conda
-  name: libpng
-  version: 1.6.43
-  build: h19919ed_0
+  version: 1.6.44
+  build: h3ca93ac_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
-  sha256: 6ad31bf262a114de5bbe0c6ba73b29ed25239d0f46f9d59700310d2ea0b3c142
-  md5: 77e398acc32617a0384553aea29e866b
+  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
+  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
   depends:
-  - libzlib >=1.2.13,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: zlib-acknowledgement
-  size: 347514
-  timestamp: 1708780763195
+  size: 348933
+  timestamp: 1726235196095
 - kind: conda
   name: libpng
-  version: 1.6.43
-  build: h2797004_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
-  sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
-  md5: 009981dd9cfcaa4dbfa25ffaed86bcae
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: zlib-acknowledgement
-  size: 288221
-  timestamp: 1708780443939
-- kind: conda
-  name: libpng
-  version: 1.6.43
-  build: h92b6c6a_0
+  version: 1.6.44
+  build: h4b8f8c9_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
-  sha256: 13e646d24b5179e6b0a5ece4451a587d759f55d9a360b7015f8f96eff4524b8f
-  md5: 65dcddb15965c9de2c0365cb14910532
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+  sha256: 12b44e58f8832798d7a5c0a7480c95e905dbd6c3558dec09739062411f9e08d1
+  md5: f32ac2c8dd390dbf169f550887ed09d9
   depends:
-  - libzlib >=1.2.13,<2.0.0a0
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
   license: zlib-acknowledgement
-  size: 268524
-  timestamp: 1708780496420
+  size: 268073
+  timestamp: 1726234803010
+- kind: conda
+  name: libpng
+  version: 1.6.44
+  build: hadc24fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 290661
+  timestamp: 1726234747153
+- kind: conda
+  name: libpng
+  version: 1.6.44
+  build: hc14010f_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 263385
+  timestamp: 1726234714421
 - kind: conda
   name: libprotobuf
   version: 4.25.3
@@ -8678,61 +8230,62 @@ packages:
   timestamp: 1724801833649
 - kind: conda
   name: libsqlite
-  version: 3.46.0
-  build: h1b8f9f3_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
-  sha256: 63af1a9e3284c7e4952364bafe7267e41e2d9d8bcc0e85a4ea4b0ec02d3693f6
-  md5: 5dadfbc1a567fe6e475df4ce3148be09
-  depends:
-  - __osx >=10.13
-  - libzlib >=1.2.13,<2.0a0
-  license: Unlicense
-  size: 908643
-  timestamp: 1718050720117
-- kind: conda
-  name: libsqlite
-  version: 3.46.0
+  version: 3.46.1
   build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.0-h2466b09_0.conda
-  sha256: 662bd7e0d63c5b8c31cca19b91649e798319b93568a2ba8d1375efb91eeb251b
-  md5: 951b0a3a463932e17414cd9f047fa03d
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.1-h2466b09_0.conda
+  sha256: ef83f90961630bc54a95e48062b05cf9c9173a822ea01784288029613a45eea4
+  md5: 8a7c1ad01f58623bfbae8d601db7cf3b
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Unlicense
-  size: 876677
-  timestamp: 1718051113874
+  size: 876666
+  timestamp: 1725354171439
 - kind: conda
   name: libsqlite
-  version: 3.46.0
-  build: hde9e2c9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
-  sha256: daee3f68786231dad457d0dfde3f7f1f9a7f2018adabdbb864226775101341a8
-  md5: 18aa975d2094c34aef978060ae7da7d8
+  version: 3.46.1
+  build: h4b8f8c9_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.1-h4b8f8c9_0.conda
+  sha256: 1d075cb823f0cad7e196871b7c57961d669cbbb6cd0e798bf50cbf520dda65fb
+  md5: 84de0078b58f899fc164303b0603ff0e
   depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0a0
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
   license: Unlicense
-  size: 865346
-  timestamp: 1718050628718
+  size: 908317
+  timestamp: 1725353652135
 - kind: conda
   name: libsqlite
-  version: 3.46.0
-  build: hfb93653_0
+  version: 3.46.1
+  build: hadc24fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
+  sha256: 9851c049abafed3ee329d6c7c2033407e2fc269d33a75c071110ab52300002b0
+  md5: 36f79405ab16bf271edb55b213836dac
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 865214
+  timestamp: 1725353659783
+- kind: conda
+  name: libsqlite
+  version: 3.46.1
+  build: hc14010f_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
-  sha256: 73048f9cb8647d3d3bfe6021c0b7d663e12cffbe9b4f31bd081e713b0a9ad8f9
-  md5: 12300188028c9bc02da965128b91b517
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.1-hc14010f_0.conda
+  sha256: 3725f962f490c5d44dae326d5f5b2e3c97f71a6322d914ccc85b5ddc2e50d120
+  md5: 58050ec1724e58668d0126a1615553fa
   depends:
   - __osx >=11.0
-  - libzlib >=1.2.13,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: Unlicense
-  size: 830198
-  timestamp: 1718050644825
+  size: 829500
+  timestamp: 1725353720793
 - kind: conda
   name: libssh2
   version: 1.11.0
@@ -8920,40 +8473,59 @@ packages:
   timestamp: 1695958011498
 - kind: conda
   name: libtiff
-  version: 4.6.0
-  build: h46a8edc_4
-  build_number: 4
+  version: 4.7.0
+  build: h5f227bf_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h5f227bf_0.conda
+  sha256: 7a348f9e5833b3ade5036eb12e8ba8b4f4518413ee777ab6666766bb93db98d1
+  md5: 2ae42f38aacee5eda6c541cad957e703
+  depends:
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
+  - libdeflate >=1.21,<1.22.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 395973
+  timestamp: 1726667328916
+- kind: conda
+  name: libtiff
+  version: 4.7.0
+  build: h6565414_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h46a8edc_4.conda
-  sha256: 8d42dd7c6602187d4351fc3b69ff526f1c262bfcbfd6ce05d06008f4e0b99b58
-  md5: a7e3a62981350e232e0e7345b5aea580
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-h6565414_0.conda
+  sha256: f50a0516ec5bbe6270f1a44feb8dae15626c62166d6c02a013bb0e5982eb0dd8
+  md5: 80eaf80d84668fa5620ac9ec1b4bf56f
   depends:
   - __glibc >=2.17,<3.0.a0
   - lerc >=4.0.0,<5.0a0
   - libdeflate >=1.21,<1.22.0a0
-  - libgcc-ng >=12
+  - libgcc >=13
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libstdcxx-ng >=12
+  - libstdcxx >=13
   - libwebp-base >=1.4.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   license: HPND
-  size: 282236
-  timestamp: 1722871642189
+  size: 428159
+  timestamp: 1726667242674
 - kind: conda
   name: libtiff
-  version: 4.6.0
-  build: h603087a_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h603087a_4.conda
-  sha256: 3b853901835167406f1c576207ec0294da4aade69c170a6e29206d454f42c259
-  md5: 362626a2aacb976ec89c91b99bfab30b
+  version: 4.7.0
+  build: h9c1d414_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-h9c1d414_0.conda
+  sha256: 2fb2d204de0ef47518587da769a0dfb114cce4ae4d4ba3b60a9f59d9759f9800
+  md5: 5f8f92ddf488a4cd50f9f5a9c4ff27c4
   depends:
-  - __osx >=10.13
+  - __osx >=11.0
   - lerc >=4.0.0,<5.0a0
-  - libcxx >=16
+  - libcxx >=17
   - libdeflate >=1.21,<1.22.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libwebp-base >=1.4.0,<2.0a0
@@ -8961,17 +8533,16 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   license: HPND
-  size: 257905
-  timestamp: 1722871821174
+  size: 367224
+  timestamp: 1726667500299
 - kind: conda
   name: libtiff
-  version: 4.6.0
-  build: hb151862_4
-  build_number: 4
+  version: 4.7.0
+  build: hb151862_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hb151862_4.conda
-  sha256: 1d5a8972f344da2e81b5a27ac0eda977803351151b8923f16cbc056515f5b8c6
-  md5: 7d35d9aa8f051d548116039f5813c8ec
+  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hb151862_0.conda
+  sha256: 63c69947251c2658b5387eef41718ce96cda7bd30698932fc6945223dca289f9
+  md5: 40a95fe7e2e82f7dac0bdc234641ca0e
   depends:
   - lerc >=4.0.0,<5.0a0
   - libdeflate >=1.21,<1.22.0a0
@@ -8983,30 +8554,8 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   license: HPND
-  size: 784657
-  timestamp: 1722871883822
-- kind: conda
-  name: libtiff
-  version: 4.6.0
-  build: hf8409c0_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-hf8409c0_4.conda
-  sha256: a974a0ed75df11a9fa1ddfe2fa21aa7ecc70e5a92a37b86b648691810f02aac6
-  md5: 16a56d4b4ee88fdad1210bf026619cc3
-  depends:
-  - __osx >=11.0
-  - lerc >=4.0.0,<5.0a0
-  - libcxx >=16
-  - libdeflate >=1.21,<1.22.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: HPND
-  size: 238731
-  timestamp: 1722871853823
+  size: 979525
+  timestamp: 1726667805938
 - kind: conda
   name: libtorch
   version: 2.4.0
@@ -9980,102 +9529,104 @@ packages:
 - kind: conda
   name: mpc
   version: 1.3.1
-  build: h24ddda3_0
+  build: h24ddda3_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.3.1-h24ddda3_0.conda
-  sha256: f6829b1a8b21e32d54114472e9b2a0d8b64c4293c22ec3dc1a53dbf7a3c78ccf
-  md5: cc7e3c1dc8cdca3b1efb4ecb2e0bd5b2
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.3.1-h24ddda3_1.conda
+  sha256: 1bf794ddf2c8b3a3e14ae182577c624fa92dea975537accff4bc7e5fea085212
+  md5: aa14b9a5196a6d8dd364164b7ce56acf
   depends:
   - __glibc >=2.17,<3.0.a0
   - gmp >=6.3.0,<7.0a0
-  - libgcc
-  - libgcc-ng >=13
+  - libgcc >=13
   - mpfr >=4.2.1,<5.0a0
   license: LGPL-3.0-or-later
   license_family: LGPL
-  size: 116611
-  timestamp: 1724862104995
+  size: 116777
+  timestamp: 1725629179524
 - kind: conda
   name: mpc
   version: 1.3.1
-  build: h8f1351a_0
+  build: h8f1351a_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_0.conda
-  sha256: ab5f8aff9a80913fe07515b7374ba275ad9cd85be551da7f468c5191abaa4678
-  md5: a02d538f0d2a3da94d21a95396fff67e
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_1.conda
+  sha256: 2700899ad03302a1751dbf2bca135407e470dd83ac897ab91dd8675d4300f158
+  md5: a5635df796b71f6ca400fc7026f50701
   depends:
   - __osx >=11.0
   - gmp >=6.3.0,<7.0a0
   - mpfr >=4.2.1,<5.0a0
   license: LGPL-3.0-or-later
   license_family: LGPL
-  size: 104306
-  timestamp: 1724862137787
+  size: 104766
+  timestamp: 1725629165420
 - kind: conda
   name: mpc
   version: 1.3.1
-  build: h9d8efa1_0
+  build: h9d8efa1_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h9d8efa1_0.conda
-  sha256: 38103e9442d6c4a734264125dd90cb3a802ab135c160684fe9a5240ac239ec49
-  md5: 0b5ec8477c260edd8bc090b20ff8f3be
+  url: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h9d8efa1_1.conda
+  sha256: dcf91571da6c2f0db96d43a1b639047def05a0e1b6436d42c9129ab14af47b10
+  md5: 0520855aaae268ea413d6bc913f1384c
   depends:
   - __osx >=10.13
   - gmp >=6.3.0,<7.0a0
   - mpfr >=4.2.1,<5.0a0
   license: LGPL-3.0-or-later
   license_family: LGPL
-  size: 107925
-  timestamp: 1724862188478
+  size: 107774
+  timestamp: 1725629348601
 - kind: conda
   name: mpfr
   version: 4.2.1
-  build: h1cfca0a_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-h1cfca0a_2.conda
-  sha256: 4ed8519e032d1f5be5e5c1324d630aee13e81498b35999a4ff8bb7f38c3dc44e
-  md5: 56b5b819e0ad2c08a67e630211629896
-  depends:
-  - __osx >=11.0
-  - gmp >=6.3.0,<7.0a0
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 346298
-  timestamp: 1722132645001
-- kind: conda
-  name: mpfr
-  version: 4.2.1
-  build: h38ae2d0_2
-  build_number: 2
+  build: h90cbb55_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h38ae2d0_2.conda
-  sha256: 016981edf60146a6c553e22457ca3d121ff52b98d24b2191b82ef2aefa89cc7f
-  md5: 168e18a2bba4f8520e6c5e38982f5847
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h90cbb55_3.conda
+  sha256: f25d2474dd557ca66c6231c8f5ace5af312efde1ba8290a6ea5e1732a4e669c0
+  md5: 2eeb50cab6652538eee8fc0bc3340c81
   depends:
   - __glibc >=2.17,<3.0.a0
   - gmp >=6.3.0,<7.0a0
-  - libgcc-ng >=12
+  - libgcc >=13
   license: LGPL-3.0-only
   license_family: LGPL
-  size: 640978
-  timestamp: 1722132616744
+  size: 634751
+  timestamp: 1725746740014
 - kind: conda
   name: mpfr
   version: 4.2.1
-  build: hc80595b_2
-  build_number: 2
+  build: haed47dc_3
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.2.1-hc80595b_2.conda
-  sha256: 24e27ad9a71f51d2858c72e7526a7aebec1a28524003fa79a9a5d682f0d5d125
-  md5: fc9b5179824146b67ad5a0b053b253ff
+  url: https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.2.1-haed47dc_3.conda
+  sha256: dddb6721dff05b8dfb654c532725330231fcb81ff1e27d885ee0cdcc9fccf1c4
+  md5: d511e58aaaabfc23136880d9956fa7a6
   depends:
   - __osx >=10.13
   - gmp >=6.3.0,<7.0a0
   license: LGPL-3.0-only
   license_family: LGPL
-  size: 373188
-  timestamp: 1722132769513
+  size: 373396
+  timestamp: 1725746891597
+- kind: conda
+  name: mpfr
+  version: 4.2.1
+  build: hb693164_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
+  sha256: 4463e4e2aba7668e37a1b8532859191b4477a6f3602a5d6b4d64ad4c4baaeac5
+  md5: 4e4ea852d54cc2b869842de5044662fb
+  depends:
+  - __osx >=11.0
+  - gmp >=6.3.0,<7.0a0
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 345517
+  timestamp: 1725746730583
 - kind: conda
   name: mpmath
   version: 1.3.0
@@ -10482,25 +10033,6 @@ packages:
 - kind: conda
   name: openblas
   version: 0.3.27
-  build: openmp_hba01982_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openblas-0.3.27-openmp_hba01982_1.conda
-  sha256: 95152278c2788198fc36648f9cef4d55adcf03e91e8918de53c6265fe957da73
-  md5: dd4456dda2cad0dcff877a0c4eb2aebf
-  depends:
-  - __osx >=10.13
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - libopenblas 0.3.27 openmp_h8869122_1
-  - llvm-openmp >=16.0.6
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5520044
-  timestamp: 1720426783674
-- kind: conda
-  name: openblas
-  version: 0.3.27
   build: pthreads_h9eca1d5_1
   build_number: 1
   subdir: linux-64
@@ -10598,7 +10130,7 @@ packages:
   md5: 7e7099ad94ac3b599808950cec30ad4e
   depends:
   - libpng >=1.6.43,<1.7.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -10619,7 +10151,7 @@ packages:
   - libgcc-ng >=12
   - libpng >=1.6.43,<1.7.0a0
   - libstdcxx-ng >=12
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-2-Clause
   license_family: BSD
@@ -10636,7 +10168,7 @@ packages:
   depends:
   - libcxx >=16
   - libpng >=1.6.43,<1.7.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-2-Clause
   license_family: BSD
@@ -10653,7 +10185,7 @@ packages:
   depends:
   - libcxx >=16
   - libpng >=1.6.43,<1.7.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-2-Clause
   license_family: BSD
@@ -10677,12 +10209,12 @@ packages:
   size: 590466
 - kind: conda
   name: openssl
-  version: 3.2.2
+  version: 3.2.3
   build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.2-h2466b09_0.conda
-  sha256: 82364e2f825b77ba8078ff69d04471ec1b29d9e23b258cedb4f9dc4ec8cfa55b
-  md5: 52a61ed990b5658e1e83b65a165ff5c5
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.3-h2466b09_0.conda
+  sha256: 2e7a1b7c9c5893fb8baa43def7b63ba046d42d200828967186e14d6954b31af1
+  md5: c96e455c42f092bd303502c1a1c97f43
   depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
@@ -10692,50 +10224,16 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 8243725
-  timestamp: 1717538556329
+  size: 8242823
+  timestamp: 1725413102587
 - kind: conda
   name: openssl
-  version: 3.2.2
-  build: h4ab18f5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.2-h4ab18f5_0.conda
-  sha256: a04f7df3ecb6f708259ff86c6baff2dbaedb8aa0f0b7be2a7f22e35609276179
-  md5: 4d217105fbae55fb38c051fce2da9399
-  depends:
-  - ca-certificates
-  - libgcc-ng >=12
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2858292
-  timestamp: 1717535514528
-- kind: conda
-  name: openssl
-  version: 3.2.2
-  build: h87427d6_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.2-h87427d6_0.conda
-  sha256: a568a8ed23306dda13bb1f9837a927ffe5a4b3ef5c5428d9166a5cb3b529bf67
-  md5: 048b2e05783df89b5f937788496abcf7
-  depends:
-  - __osx >=10.13
-  - ca-certificates
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2511857
-  timestamp: 1717535708321
-- kind: conda
-  name: openssl
-  version: 3.2.2
-  build: hfb2fe0b_0
+  version: 3.2.3
+  build: h8359307_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.2-hfb2fe0b_0.conda
-  sha256: 5b7724d741b3c14bf22f2f02b11d079a1984b4e4134e5f9fc89fe75e6dbc7e74
-  md5: 751a99906da2ed9794d0f7cd73475f26
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.3-h8359307_0.conda
+  sha256: 63e81d48e507160e128f6a064030a631bfe8cfabc1b815fb0bb3fc25a61ada8a
+  md5: 5e60cda9de6b19d7dee8af44ae076b02
   depends:
   - __osx >=11.0
   - ca-certificates
@@ -10743,8 +10241,43 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2860273
-  timestamp: 1717535475655
+  size: 2849989
+  timestamp: 1725410766174
+- kind: conda
+  name: openssl
+  version: 3.2.3
+  build: hb9d3cd8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.3-hb9d3cd8_0.conda
+  sha256: 15ba43d945c2df902d9d7cc452b3eebc17c2313aecafbd89a337427872f2f9aa
+  md5: f464ae07599e3e3e915bfbf2dae3d9b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2863862
+  timestamp: 1725410833434
+- kind: conda
+  name: openssl
+  version: 3.2.3
+  build: hd23fc13_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.3-hd23fc13_0.conda
+  sha256: 28343a34af7fad084fd3d73b5488a020cebcac8ffb0e360bfb5f87821abe344e
+  md5: d2479c0fb9a34b7e2a4fb0edd72e6be2
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2513875
+  timestamp: 1725411187
 - kind: conda
   name: orc
   version: 2.0.0
@@ -10896,40 +10429,17 @@ packages:
 - kind: conda
   name: pillow
   version: 10.4.0
-  build: py312h287a98d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py312h287a98d_0.conda
-  sha256: f3bca9472702f32bf85196efbf013e9dabe130776e76c7f81062f18682f33a05
-  md5: 59ea71eed98aee0bebbbdd3b118167c7
-  depends:
-  - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.16,<3.0a0
-  - libgcc-ng >=12
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libxcb >=1.16,<1.17.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openjpeg >=2.5.2,<3.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - tk >=8.6.13,<8.7.0a0
-  license: HPND
-  size: 42068301
-  timestamp: 1719903698022
-- kind: conda
-  name: pillow
-  version: 10.4.0
-  build: py312h381445a_0
+  build: py312h381445a_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py312h381445a_0.conda
-  sha256: 2c76c1ded20c5199d134ccecab596412510a016218f342914fd85384a850e7ed
-  md5: cc1e714c3cc43c59d9d0efa228c16364
+  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py312h381445a_1.conda
+  sha256: 0b52e708ac4b72e6e1608de517cd4c8e6517dd525e23163a69bf73c7261399fc
+  md5: c57e54ae4acca720fb3a44bee93cb5b9
   depends:
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   - libwebp-base >=1.4.0,<2.0a0
   - libxcb >=1.16,<1.17.0a0
   - libzlib >=1.3.1,<2.0a0
@@ -10941,22 +10451,74 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: HPND
-  size: 42560613
-  timestamp: 1719904152461
+  size: 42468305
+  timestamp: 1726075694989
 - kind: conda
   name: pillow
   version: 10.4.0
-  build: py312h39b1d8d_0
+  build: py312h56024de_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py312h56024de_1.conda
+  sha256: a0961e7ff663d4c7a82478ff45fba72a346070f2a017a9b56daff279c0dbb8e2
+  md5: 4bd6077376c7f9c1ce33fd8319069e5b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.16,<1.17.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42689452
+  timestamp: 1726075285193
+- kind: conda
+  name: pillow
+  version: 10.4.0
+  build: py312h683ea77_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.4.0-py312h683ea77_1.conda
+  sha256: 1e8d489190aa0b4682f52468efe4db46b37e50679c64879696e42578c9a283a4
+  md5: fb17ec3065f089dad64d9b597b1e8ce4
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.16,<1.17.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42329265
+  timestamp: 1726075276862
+- kind: conda
+  name: pillow
+  version: 10.4.0
+  build: py312h8609ca0_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.4.0-py312h39b1d8d_0.conda
-  sha256: 7c4244fa62cf630375531723631764a276eb06eeb5cc345a8e55a091aec1e52d
-  md5: 461c9897622e08c614087f9c9b9a22ce
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.4.0-py312h8609ca0_1.conda
+  sha256: 980139e8dfc9da20a96a6260c796eb7c77c5c5658ee4032f33ebe0ac980b2e2b
+  md5: b71f08e05207fa6a9155e8581c3d473e
   depends:
   - __osx >=11.0
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   - libwebp-base >=1.4.0,<2.0a0
   - libxcb >=1.16,<1.17.0a0
   - libzlib >=1.3.1,<2.0a0
@@ -10966,32 +10528,8 @@ packages:
   - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
   license: HPND
-  size: 42347638
-  timestamp: 1719903919946
-- kind: conda
-  name: pillow
-  version: 10.4.0
-  build: py312hbd70edc_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.4.0-py312hbd70edc_0.conda
-  sha256: 38b6e8c63c8ebfd9c8552312cecd385ec7bfad6e5733f5c6b6df0db801ea5f43
-  md5: 8d55e92fa6380ac8c245f253b096fefd
-  depends:
-  - __osx >=10.13
-  - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.16,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libxcb >=1.16,<1.17.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openjpeg >=2.5.2,<3.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - tk >=8.6.13,<8.7.0a0
-  license: HPND
-  size: 42081826
-  timestamp: 1719903909255
+  size: 42413280
+  timestamp: 1726075422684
 - kind: conda
   name: pip
   version: '24.2'
@@ -11063,44 +10601,34 @@ packages:
 - kind: conda
   name: pthread-stubs
   version: '0.4'
-  build: h27ca646_1001
-  build_number: 1001
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
-  sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
-  md5: d3f26c6494d4105d4ecb85203d687102
-  license: MIT
-  license_family: MIT
-  size: 5696
-  timestamp: 1606147608402
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: h36c2ea0_1001
-  build_number: 1001
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
-  sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
-  md5: 22dad4df6e8630e8dff2428f6f6a7036
-  depends:
-  - libgcc-ng >=7.5.0
-  license: MIT
-  license_family: MIT
-  size: 5625
-  timestamp: 1606147468727
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: hc929b4f_1001
-  build_number: 1001
+  build: h00291cd_1002
+  build_number: 1002
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
-  sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
-  md5: addd19059de62181cd11ae8f4ef26084
+  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 5653
-  timestamp: 1606147699844
+  size: 8364
+  timestamp: 1726802331537
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: hb9d3cd8_1002
+  build_number: 1002
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
 - kind: conda
   name: pthread-stubs
   version: '0.4'
@@ -11116,6 +10644,21 @@ packages:
   license_family: MIT
   size: 6417
   timestamp: 1606147814351
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: hd74edd7_1002
+  build_number: 1002
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
 - kind: conda
   name: pthreads-win32
   version: 2.9.1
@@ -11283,17 +10826,16 @@ packages:
   timestamp: 1714452954882
 - kind: conda
   name: pybind11
-  version: 2.13.5
-  build: py312h6142ec9_1
-  build_number: 1
+  version: 2.13.6
+  build: py312h6142ec9_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-2.13.5-py312h6142ec9_1.conda
-  sha256: 2db6637c1267f6988521b552fe733922fbb3a4bf26344a865afa0e231e6f6f80
-  md5: 53fcfa1d6cdf6c0fb01bbbec52eb369d
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-2.13.6-py312h6142ec9_0.conda
+  sha256: 2d8e4539e7d3971ea21281e5b8ec91191a9483a6697a7cedb0cb8a6479b1b6d7
+  md5: 4e2543cc0512ac2291cc489968671cc4
   depends:
   - __osx >=11.0
   - libcxx >=17
-  - pybind11-global 2.13.5 py312h6142ec9_1
+  - pybind11-global 2.13.6 py312h6142ec9_0
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
@@ -11301,62 +10843,59 @@ packages:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 196749
-  timestamp: 1725347133592
+  size: 197587
+  timestamp: 1726288670738
 - kind: conda
   name: pybind11
-  version: 2.13.5
-  build: py312h68727a3_1
-  build_number: 1
+  version: 2.13.6
+  build: py312h68727a3_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pybind11-2.13.5-py312h68727a3_1.conda
-  sha256: adf25b1ffa342b30124e8684b9f7b944212f4fcd17713315fb2bd64c26ac860e
-  md5: 3ee14496dd5f7b80b86860a939e2d325
+  url: https://conda.anaconda.org/conda-forge/linux-64/pybind11-2.13.6-py312h68727a3_0.conda
+  sha256: b1953f6e289af3f79fe765f96eceea3a010c88fe7b1646b08720284d6d15fba9
+  md5: 45455d0e8baf0327e620f32853364572
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
-  - pybind11-global 2.13.5 py312h68727a3_1
+  - pybind11-global 2.13.6 py312h68727a3_0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   constrains:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 195973
-  timestamp: 1725346774395
+  size: 197164
+  timestamp: 1726288425287
 - kind: conda
   name: pybind11
-  version: 2.13.5
-  build: py312hc5c4d5f_1
-  build_number: 1
+  version: 2.13.6
+  build: py312hc5c4d5f_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pybind11-2.13.5-py312hc5c4d5f_1.conda
-  sha256: d6e4cd158d6ecc6b4b463135cd518570f648be22716371c7090f6035226128d8
-  md5: 6c6e75d184557549fc0fff138e05d83f
+  url: https://conda.anaconda.org/conda-forge/osx-64/pybind11-2.13.6-py312hc5c4d5f_0.conda
+  sha256: 2a8042ec4f6d9165d9363ae0d7c7c0d2509d78b79ab06c9b77df327b21f0ac5e
+  md5: ae3364f234d7a5dc3a323ce2cc5692cd
   depends:
   - __osx >=10.13
   - libcxx >=17
-  - pybind11-global 2.13.5 py312hc5c4d5f_1
+  - pybind11-global 2.13.6 py312hc5c4d5f_0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   constrains:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 196415
-  timestamp: 1725346822811
+  size: 197469
+  timestamp: 1726288496613
 - kind: conda
   name: pybind11
-  version: 2.13.5
-  build: py312hd5eb7cc_1
-  build_number: 1
+  version: 2.13.6
+  build: py312hd5eb7cc_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pybind11-2.13.5-py312hd5eb7cc_1.conda
-  sha256: ca49bc0ee237ec56f06d76024a9fac51891f97878349f6f977c5bc71907cf479
-  md5: 76dbf639ce67976ff1e153ea4eefb36b
+  url: https://conda.anaconda.org/conda-forge/win-64/pybind11-2.13.6-py312hd5eb7cc_0.conda
+  sha256: 950dbb618c98a7a6d8c29f48b832c8659ae3072ad9dd9fc8be974cbaa07a12e3
+  md5: 88a5362af2316d51ca18fc0bd65334a5
   depends:
-  - pybind11-global 2.13.5 py312hd5eb7cc_1
+  - pybind11-global 2.13.6 py312hd5eb7cc_0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
@@ -11366,17 +10905,16 @@ packages:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 245724
-  timestamp: 1725347315708
+  size: 246661
+  timestamp: 1726288799874
 - kind: conda
   name: pybind11-global
-  version: 2.13.5
-  build: py312h6142ec9_1
-  build_number: 1
+  version: 2.13.6
+  build: py312h6142ec9_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-global-2.13.5-py312h6142ec9_1.conda
-  sha256: f24fcb7d60a3dbe458d6877ffa05c7c1d86679641ddd83c4d204cee7a1f27b3f
-  md5: 0dfa96d906ce2e4641bff67a67eb7b25
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-global-2.13.6-py312h6142ec9_0.conda
+  sha256: 189cd8b48a94499a0d0173c57c2d49ce66cecc55ed21b2ef9f97f6b9ae4be11f
+  md5: 466b4c307f79a810a03d1d255768781b
   depends:
   - __osx >=11.0
   - libcxx >=17
@@ -11387,17 +10925,16 @@ packages:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 181288
-  timestamp: 1725347044789
+  size: 182620
+  timestamp: 1726288611070
 - kind: conda
   name: pybind11-global
-  version: 2.13.5
-  build: py312h68727a3_1
-  build_number: 1
+  version: 2.13.6
+  build: py312h68727a3_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pybind11-global-2.13.5-py312h68727a3_1.conda
-  sha256: 1592d8575d50ece8b277b088a703dd4b6c0adc256c59344912ee4f59531e1ef9
-  md5: 3884120192ff6eef9aa012965978e7f7
+  url: https://conda.anaconda.org/conda-forge/linux-64/pybind11-global-2.13.6-py312h68727a3_0.conda
+  sha256: dd219fe0af0813100f21b20075c75353119187113aefdb0a8815dcb04a54ebd1
+  md5: 1bfa57419da39a47cdcef5e34c87bdd8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -11408,17 +10945,16 @@ packages:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 180371
-  timestamp: 1725346758060
+  size: 181171
+  timestamp: 1726288408903
 - kind: conda
   name: pybind11-global
-  version: 2.13.5
-  build: py312hc5c4d5f_1
-  build_number: 1
+  version: 2.13.6
+  build: py312hc5c4d5f_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pybind11-global-2.13.5-py312hc5c4d5f_1.conda
-  sha256: 59c66662141e027e1c54ea483020629a49c232db82df38aa13ebab64e7d93ed5
-  md5: d959e791ce7b7c254b01c7f4ffee8f30
+  url: https://conda.anaconda.org/conda-forge/osx-64/pybind11-global-2.13.6-py312hc5c4d5f_0.conda
+  sha256: 2da5ed0cab7f390ee2d09509d2526e1398fd3f935885d49e23014b1fba64cbc4
+  md5: 8499981aa7d9ab4028867e568478b093
   depends:
   - __osx >=10.13
   - libcxx >=17
@@ -11428,17 +10964,16 @@ packages:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 180783
-  timestamp: 1725346771227
+  size: 182225
+  timestamp: 1726288456156
 - kind: conda
   name: pybind11-global
-  version: 2.13.5
-  build: py312hd5eb7cc_1
-  build_number: 1
+  version: 2.13.6
+  build: py312hd5eb7cc_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pybind11-global-2.13.5-py312hd5eb7cc_1.conda
-  sha256: 9c037c3133b8afe40e337f4da08ee7a0ce095c002876a34329c1af0a573f047c
-  md5: 8de5ba32305762d84aa9148244932d8c
+  url: https://conda.anaconda.org/conda-forge/win-64/pybind11-global-2.13.6-py312hd5eb7cc_0.conda
+  sha256: 38dceb1e9e6a84ed2968688232b0fa1f64bbbd5add145ecf0c341894bc36a063
+  md5: d24476f39abac6b645fd1782ff294d16
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -11449,8 +10984,8 @@ packages:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 180471
-  timestamp: 1725346973419
+  size: 182101
+  timestamp: 1726288668761
 - kind: conda
   name: pygments
   version: 2.18.0
@@ -11774,40 +11309,6 @@ packages:
   license_family: BSD
   size: 25846049
   timestamp: 1724895807565
-- kind: conda
-  name: pytorch-cuda
-  version: '12.4'
-  build: h3fd98bf_6
-  build_number: 6
-  subdir: win-64
-  url: https://conda.anaconda.org/pytorch/win-64/pytorch-cuda-12.4-h3fd98bf_6.tar.bz2
-  sha256: 69540a67426e3e23916bfbcc36084f56874c25d249d33262d7531813cd5db084
-  md5: c482df2da1a8a53a037ad7cf25d60249
-  depends:
-  - cuda-cudart >=12.4,<12.5
-  - cuda-cudart-dev >=12.4,<12.5
-  - cuda-cupti >=12.4,<12.5
-  - cuda-libraries >=12.4,<12.5
-  - cuda-libraries-dev >=12.4,<12.5
-  - cuda-nvrtc >=12.4,<12.5
-  - cuda-nvrtc-dev >=12.4,<12.5
-  - cuda-nvtx >=12.4,<12.5
-  - cuda-runtime >=12.4,<12.5
-  - libcublas >=12.4.2.65,<12.4.5.8
-  - libcublas-dev >=12.4.2.65,<12.4.5.8
-  - libcufft >=11.2.0.44,<11.2.1.3
-  - libcufft-dev >=11.2.0.44,<11.2.1.3
-  - libcusolver >=11.6.0.99,<11.6.1.9
-  - libcusolver-dev >=11.6.0.99,<11.6.1.9
-  - libcusparse >=12.3.0.142,<12.3.1.170
-  - libcusparse-dev >=12.3.0.142,<12.3.1.170
-  - libnpp >=12.2.5.2,<12.2.5.30
-  - libnpp-dev >=12.2.5.2,<12.2.5.30
-  - libnvjitlink >=12.4.99,<12.4.127
-  - libnvjpeg >=12.3.1.89,<12.3.1.117
-  - libnvjpeg-dev >=12.3.1.89,<12.3.1.117
-  size: 7268
-  timestamp: 1713892159908
 - kind: conda
   name: rdma-core
   version: '53.0'
@@ -12239,53 +11740,50 @@ packages:
   timestamp: 1620240338595
 - kind: conda
   name: sleef
-  version: 3.6.1
-  build: h01aa1be_3
-  build_number: 3
+  version: '3.7'
+  build: h01aa1be_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/sleef-3.6.1-h01aa1be_3.conda
-  sha256: 6ce703ce8fce607c5e33749c4ef47aff16747adf83db366e20ad3682bb65c334
-  md5: e8c6887c682996f121d8c14894feec0f
+  url: https://conda.anaconda.org/conda-forge/osx-64/sleef-3.7-h01aa1be_0.conda
+  sha256: b80dc7daffde8978dc8386d56d137c2fa147973c09e914a2e00fc5ab5248bf8f
+  md5: 48ace35e33cfaf63729c933bc3328dcf
   depends:
   - __osx >=10.13
   - libcxx >=17
   - llvm-openmp >=17.0.6
   license: BSL-1.0
-  size: 1489951
-  timestamp: 1724609281918
+  size: 1490824
+  timestamp: 1726638525854
 - kind: conda
   name: sleef
-  version: 3.6.1
-  build: h1b44611_3
-  build_number: 3
+  version: '3.7'
+  build: h1b44611_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.6.1-h1b44611_3.conda
-  sha256: 06f1f324fc01481a85bcdf3e62e944101c60c31faa7920ebac6b8d153c2fef11
-  md5: af4dbe128af0840dcaeb4d40eb27ab73
+  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.7-h1b44611_0.conda
+  sha256: 4fbd2d6daa2b9cae0ba704cbbbb45a4f2f412e03e2028ec851205f09caa9139a
+  md5: f8b9a3928def0a7f4e37c67045542584
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
-  - libgcc-ng >=13
-  - libstdcxx-ng >=13
+  - libgcc >=13
+  - libstdcxx >=13
   license: BSL-1.0
-  size: 1914535
-  timestamp: 1724609202130
+  size: 1920639
+  timestamp: 1726638538131
 - kind: conda
   name: sleef
-  version: 3.6.1
-  build: h7783ee8_3
-  build_number: 3
+  version: '3.7'
+  build: h7783ee8_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.6.1-h7783ee8_3.conda
-  sha256: 82de3a7bbdba94d216bc19de5d6e004d8aff6c8f977a86688fccf8677d30219e
-  md5: c31578d67107457a879cfb25516bf896
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.7-h7783ee8_0.conda
+  sha256: e3b72bd02545ecd5b6a5f0578eff527f10e718b8807e83ebecb2cba16e764bba
+  md5: cf4b93e9daf2dc16a23d1f9402b34beb
   depends:
   - __osx >=11.0
   - libcxx >=17
   - llvm-openmp >=17.0.6
   license: BSL-1.0
-  size: 568928
-  timestamp: 1724609366064
+  size: 568810
+  timestamp: 1726638560497
 - kind: conda
   name: snappy
   version: 1.2.1
@@ -12581,95 +12079,93 @@ packages:
   timestamp: 1711086612058
 - kind: conda
   name: tapi
-  version: 1100.0.11
-  build: h9ce4665_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
-  sha256: 34b18ce8d1518b67e333ca1d3af733c3976ecbdf3a36b727f9b4dedddcc588fa
-  md5: f9ff42ccf809a21ba6f8607f8de36108
+  version: 1300.6.5
+  build: h03f4b80_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+  sha256: 37cd4f62ec023df8a6c6f9f6ffddde3d6620a83cbcab170a8fff31ef944402e5
+  md5: b703bc3e6cba5943acf0e5f987b5d0e2
   depends:
-  - libcxx >=10.0.0.a0
+  - __osx >=11.0
+  - libcxx >=17.0.0.a0
+  - ncurses >=6.5,<7.0a0
   license: NCSA
   license_family: MIT
-  size: 201044
-  timestamp: 1602664232074
+  size: 207679
+  timestamp: 1725491499758
 - kind: conda
   name: tapi
-  version: 1100.0.11
-  build: he4954df_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
-  sha256: 1709265fbee693a9e8b4126b0a3e68a6c4718b05821c659279c1af051f2d40f3
-  md5: d83362e7d0513f35f454bc50b0ca591d
+  version: 1300.6.5
+  build: h390ca13_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+  sha256: f97372a1c75b749298cb990405a690527e8004ff97e452ed2c59e4bc6a35d132
+  md5: c6ee25eb54accb3f1c8fc39203acfaf1
   depends:
-  - libcxx >=11.0.0.a0
+  - __osx >=10.13
+  - libcxx >=17.0.0.a0
+  - ncurses >=6.5,<7.0a0
   license: NCSA
   license_family: MIT
-  size: 191416
-  timestamp: 1602687595316
+  size: 221236
+  timestamp: 1725491044729
 - kind: conda
   name: tbb
-  version: 2021.12.0
-  build: h37c8870_4
-  build_number: 4
+  version: 2021.13.0
+  build: h37c8870_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.12.0-h37c8870_4.conda
-  sha256: e26826f2a677f9efed56b137706b95e77f3f7cd8d7eda70d7f4b9ef897599edb
-  md5: a1391c6e22a72e21c4cb18f574a2105e
+  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.13.0-h37c8870_0.conda
+  sha256: 9a20a60ebf743f99e38a7be049f8ca90f264851c13dc8cb41eb09d854a631e31
+  md5: 89742f5ac7aeb5c44ec2b4c3c6692c3c
   depends:
   - __osx >=10.13
   - libcxx >=17
   - libhwloc >=2.11.1,<2.11.2.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 171699
-  timestamp: 1724905633043
+  size: 159453
+  timestamp: 1725532728568
 - kind: conda
   name: tbb
-  version: 2021.12.0
-  build: h7b3277c_4
-  build_number: 4
+  version: 2021.13.0
+  build: h7b3277c_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.12.0-h7b3277c_4.conda
-  sha256: 16fa99fbe3e334000ac19df1a81d86339740b29f99a84608adf1b2fd08771769
-  md5: a8790535719e5f6321d7dcea1e651d93
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.13.0-h7b3277c_0.conda
+  sha256: 4a16118d5f71da9e8177921be996da87112a55fe53a700ab5dffe14ae2b6ecba
+  md5: a8a0feb11d51d4a0a2e56fbd53c628cf
   depends:
   - __osx >=11.0
   - libcxx >=17
   - libhwloc >=2.11.1,<2.11.2.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 128795
-  timestamp: 1724905730211
+  size: 115213
+  timestamp: 1725532720037
 - kind: conda
   name: tbb
-  version: 2021.12.0
-  build: h84d6215_4
-  build_number: 4
+  version: 2021.13.0
+  build: h84d6215_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.12.0-h84d6215_4.conda
-  sha256: a079dcf42804a841ac2b63784f42e0d2e93401833d4a7d44ddf05b767794d578
-  md5: 1fa72fdeb88f538018612ce2ed9fc789
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h84d6215_0.conda
+  sha256: 7d4d3ad608dc6ae5a7e0f431f784985398a18bcde2ba3ce19cc32f61e2defd98
+  md5: ee6f7fd1e76061ef1fa307d41fa86a96
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc
-  - libgcc-ng >=13
+  - libgcc >=13
   - libhwloc >=2.11.1,<2.11.2.0a0
-  - libstdcxx
-  - libstdcxx-ng >=13
+  - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
-  size: 186953
-  timestamp: 1724905442040
+  size: 175779
+  timestamp: 1725532539822
 - kind: conda
   name: tbb
-  version: 2021.12.0
-  build: hc790b64_4
-  build_number: 4
+  version: 2021.13.0
+  build: hc790b64_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_4.conda
-  sha256: d23e589311be6aeacbfb8371bd65d8637c5acc83a149baccc57d2621644fe158
-  md5: bce92c19a6cb64b47866b7271363f747
+  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
+  sha256: 990dbe4fb42f14700c22bd434d8312607bf8d0bd9f922b054e51fda14c41994c
+  md5: 28496a1e6af43c63927da4f80260348d
   depends:
   - libhwloc >=2.11.1,<2.11.2.0a0
   - ucrt >=10.0.20348.0
@@ -12677,8 +12173,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 161921
-  timestamp: 1724906383699
+  size: 151494
+  timestamp: 1725532984828
 - kind: conda
   name: tk
   version: 8.6.13
@@ -12836,61 +12332,61 @@ packages:
 - kind: conda
   name: vc
   version: '14.3'
-  build: h8a93ad2_20
-  build_number: 20
+  build: h8a93ad2_21
+  build_number: 21
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_20.conda
-  sha256: 23ac5feb15a9adf3ab2b8c4dcd63650f8b7ae860c5ceb073e49cf71d203eddef
-  md5: 8558f367e1d7700554f7cdb823c46faf
+  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_21.conda
+  sha256: f14f5238c2e2516e292af43d91df88f212d769b4853eb46d03291793dcf00da9
+  md5: e632a9b865d4b653aa656c9fb4f4817c
   depends:
   - vc14_runtime >=14.40.33810
   track_features:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
-  size: 17391
-  timestamp: 1717709040616
+  size: 17243
+  timestamp: 1725984095174
 - kind: conda
   name: vc14_runtime
   version: 14.40.33810
-  build: hcc2c482_20
-  build_number: 20
+  build: ha82c5b3_21
+  build_number: 21
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_20.conda
-  sha256: bba8daa6f78b26b48fb7e1377eb52160e25495710bf53146c5f405bd50565982
-  md5: ad33c7cd933d69b9dee0f48317cdf137
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_21.conda
+  sha256: c3bf51bff7db39ad7e890dbef1b1026df0af36975aea24dea7c5fe1e0b382c40
+  md5: b3ebb670caf046e32b835fbda056c4f9
   depends:
   - ucrt >=10.0.20348.0
   constrains:
-  - vs2015_runtime 14.40.33810.* *_20
+  - vs2015_runtime 14.40.33810.* *_21
   license: LicenseRef-ProprietaryMicrosoft
   license_family: Proprietary
-  size: 751028
-  timestamp: 1724712684919
+  size: 751757
+  timestamp: 1725984166774
 - kind: conda
   name: vs2015_runtime
   version: 14.40.33810
-  build: h3bf8584_20
-  build_number: 20
+  build: h3bf8584_21
+  build_number: 21
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
-  sha256: 0c2803f7a788c51f28235a7228dc2ab3f107b4b16ab0845a3e595c8c51e50a7a
-  md5: c21f1b4a3a30bbc3ef35a50957578e0e
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_21.conda
+  sha256: 472410455c381e406ec8c1d3e0342b48ee23122ef7ffb22a09d9763ca5df4d20
+  md5: b3f37db7b7ae1c22600fa26a63ed99b3
   depends:
   - vc14_runtime >=14.40.33810
   license: BSD-3-Clause
   license_family: BSD
-  size: 17395
-  timestamp: 1717709043353
+  size: 17241
+  timestamp: 1725984096440
 - kind: conda
   name: vs2019_win-64
   version: 19.29.30139
-  build: he1865b1_20
-  build_number: 20
+  build: he1865b1_21
+  build_number: 21
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_20.conda
-  sha256: b9b3faf4fa20301ad1886cfde20d339ea6c2e95de8f4710e0b49af1ca1d3a657
-  md5: bc2f92e632f5c6b0d94e365546c7fc6e
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_21.conda
+  sha256: e48a213573447712231db976ba6583398f1dd6939bc9b5e345a6b445692e4f2b
+  md5: 2586afd2c0da404d00a5796789b46757
   depends:
   - vswhere
   constrains:
@@ -12899,8 +12395,8 @@ packages:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
-  size: 19744
-  timestamp: 1716231200159
+  size: 19827
+  timestamp: 1725984100160
 - kind: conda
   name: vswhere
   version: 3.1.7
@@ -12916,11 +12412,12 @@ packages:
 - kind: conda
   name: watchfiles
   version: 0.24.0
-  build: py312h12e396e_0
+  build: py312h12e396e_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-0.24.0-py312h12e396e_0.conda
-  sha256: 47aefa3d6ea182c497e72a7e9f6c13e6d4b0803bf1761b65916e16a9262e8928
-  md5: fffe9095efb67715334a77594dca4dcc
+  url: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-0.24.0-py312h12e396e_1.conda
+  sha256: 04227e72c1e8c30afca18860491462461d35ffa1dba552770adce61794aa7114
+  md5: fa5bb5b364b0f8162d67c31009c985c9
   depends:
   - __glibc >=2.17,<3.0.a0
   - anyio >=3.0.0
@@ -12931,16 +12428,17 @@ packages:
   - __glibc >=2.17
   license: MIT
   license_family: MIT
-  size: 397158
-  timestamp: 1724917076636
+  size: 397205
+  timestamp: 1725347165866
 - kind: conda
   name: watchfiles
   version: 0.24.0
-  build: py312h2615798_0
+  build: py312h2615798_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/watchfiles-0.24.0-py312h2615798_0.conda
-  sha256: 950c7adc2cab3fcddfbe745e5ee097d321ad8a5a6503f1b7a092062c5712cffd
-  md5: 8f131c9e7ce00b3d23d31b3049e78eae
+  url: https://conda.anaconda.org/conda-forge/win-64/watchfiles-0.24.0-py312h2615798_1.conda
+  sha256: 26b608ba4f60fd3336b82c2ef25dd25b4147c1618bfe97f7bd5c58d281cc5715
+  md5: 98998886ae5f85f88e569ae8d7f2ae0c
   depends:
   - anyio >=3.0.0
   - python >=3.12,<3.13.0a0
@@ -12950,16 +12448,17 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 294525
-  timestamp: 1724917910391
+  size: 294587
+  timestamp: 1725347685319
 - kind: conda
   name: watchfiles
   version: 0.24.0
-  build: py312h669792a_0
+  build: py312h669792a_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/watchfiles-0.24.0-py312h669792a_0.conda
-  sha256: ae1bb6e903dc397c20b166bee9871818cb40cd9d6b90e8b90b9c4041d32d90c5
-  md5: b19db87f857e44382c0cfd671a066a6a
+  url: https://conda.anaconda.org/conda-forge/osx-64/watchfiles-0.24.0-py312h669792a_1.conda
+  sha256: f1d9f268ea350296950c710bdbc6fd9e15ee5a86115e6448e7cb80a6bca824ec
+  md5: 37e5423e63089d1e26578ef1a41c5f82
   depends:
   - __osx >=10.13
   - anyio >=3.0.0
@@ -12969,16 +12468,17 @@ packages:
   - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 349830
-  timestamp: 1724917415506
+  size: 349565
+  timestamp: 1725347153031
 - kind: conda
   name: watchfiles
   version: 0.24.0
-  build: py312he431725_0
+  build: py312he431725_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-0.24.0-py312he431725_0.conda
-  sha256: cee77f7ae99d301edcc4575206c205d187b4e4f20362eca64be79c9d90ea37b7
-  md5: 4fbe26cfc27769c91d8f71edee878f78
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-0.24.0-py312he431725_1.conda
+  sha256: e92ec8593fee0ce6cb2b565900eb9792c73efacc129d2bf92dba074bca505598
+  md5: 7fd741404e6fcab22a988ee6742dc778
   depends:
   - __osx >=11.0
   - anyio >=3.0.0
@@ -12989,8 +12489,8 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 342459
-  timestamp: 1724917334707
+  size: 342896
+  timestamp: 1725347401713
 - kind: conda
   name: wcwidth
   version: 0.2.13
@@ -13111,27 +12611,34 @@ packages:
 - kind: conda
   name: xorg-libxau
   version: 1.0.11
-  build: h0dc2134_0
+  build: h00291cd_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
-  sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
-  md5: 9566b4c29274125b0266d0177b5eb97b
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+  sha256: 96177823ec38336b0f4b7e7c2413da61f8d008d800cc4a5b8ad21f9128fb7de0
+  md5: c6cc91149a08402bbb313c5dc0142567
+  depends:
+  - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 13071
-  timestamp: 1684638167647
+  size: 13176
+  timestamp: 1727034772877
 - kind: conda
   name: xorg-libxau
   version: 1.0.11
-  build: hb547adb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
-  sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
-  md5: ca73dc4f01ea91e44e3ed76602c5ea61
+  build: hb9d3cd8_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
+  md5: 77cbc488235ebbaab2b6e912d3934bae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 13667
-  timestamp: 1684638272445
+  size: 14679
+  timestamp: 1727034741045
 - kind: conda
   name: xorg-libxau
   version: 1.0.11
@@ -13150,17 +12657,18 @@ packages:
 - kind: conda
   name: xorg-libxau
   version: 1.0.11
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
-  sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
-  md5: 2c80dc38fface310c9bd81b17037fee5
+  build: hd74edd7_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+  sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
+  md5: 7e0125f8fb619620a0011dc9297e2493
   depends:
-  - libgcc-ng >=12
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 14468
-  timestamp: 1684637984591
+  size: 13515
+  timestamp: 1727034783560
 - kind: conda
   name: xorg-libxdmcp
   version: 1.1.3

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "momentum"
-channels = ["nvidia", "conda-forge", "pytorch"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 version = "0.1.0"
 description = "A library providing foundational algorithms for human kinematic motion and numerical optimization solvers to apply human motion in various applications"
@@ -121,7 +121,6 @@ build_pymomentum = { cmd = "pip install -e ." }
 #=========
 
 [target.win-64.dependencies]
-pytorch-cuda = ">=12.1,<13"
 
 [target.win-64.tasks]
 configure = { cmd = "cmake -S . -B build -G 'Visual Studio 17 2022' -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_SHARED_LIBS=OFF -DMOMENTUM_BUILD_IO_FBX=ON -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON -DMOMENTUM_USE_SYSTEM_PYBIND11=ON -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON -DMOMENTUM_BUILD_TESTING=ON -DMOMENTUM_BUILD_EXAMPLES=ON -DMOMENTUM_BUILD_PYMOMENTUM=OFF", inputs = [


### PR DESCRIPTION
### Summary

No packages from the `pytorch` and `nvidia` channels are needed at the moment.

### Test Plan

CI

### Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`
