### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,11 @@
 
 > Please provide a summary of the changes made and the issue that is being addressed.
 
-## Test Plan
-
-> Please describe the tests you conducted to verify your changes.
-
 ## Checklist:
 
 - [ ] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
 - [ ] Codebase formatted by running `pixi run lint`
+
+## Test Plan
+
+> Please describe the tests you conducted to verify your changes.


### PR DESCRIPTION
## Summary

Move the `Checklist` section above `Test Plan` in the GitHub PR template, so that `Checklist` is not included in `Test Plan` when imported. This is because all sections below the `Test Plan` section in a GitHub pull request are automatically included in the `Test Plan` section when imported.

## Test Plan

Check the imported PR

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`
