### PR TITLE
Remove gtest dependency from pymomentum.geometry

### DIFF
--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -111,7 +111,6 @@ mt_python_binding(
     ${TORCH_LIBRARIES}
   LINK_LIBRARIES
     character
-    character_test_helper
     io_fbx
     io_gltf
     io_marker
@@ -169,6 +168,15 @@ mt_python_binding(
 if(MOMENTUM_BUILD_TESTING)
   enable_testing()
   mt_setup_gtest()
+
+  mt_python_binding(
+    NAME geometry_test_helper
+    PYMOMENTUM_HEADERS_VARS geometry_test_helper_public_headers
+    PYMOMENTUM_SOURCES_VARS geometry_test_helper_sources
+    INCLUDE_DIRECTORIES
+    LINK_LIBRARIES
+      character_test_helper
+  )
 
   mt_test(
     NAME tensor_utility_test

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -61,6 +61,13 @@ geometry_sources = [
     "geometry/momentum_io.cpp",
 ]
 
+geometry_test_helper_public_headers = [
+]
+
+geometry_test_helper_sources = [
+    "geometry/geometry_test_helper_pybind.cpp",
+]
+
 quaternion_public_headers = [
 ]
 

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -29,7 +29,6 @@
 #include <momentum/io/shape/blend_shape_io.h>
 #include <momentum/math/mesh.h>
 #include <momentum/math/mppca.h>
-#include <momentum/test/character/character_helpers.h>
 
 #include <pybind11/eigen.h>
 #include <pybind11/numpy.h>
@@ -1686,31 +1685,6 @@ you will likely want to retarget the parameters using the :meth:`mapParameters` 
       py::arg("motion_data"),
       py::arg("source_character"),
       py::arg("target_character"));
-
-  // createTestCharacter()
-  m.def(
-      "test_character",
-      &momentum::createTestCharacter<float>,
-      R"(Create a simple 3-joint test character.  This is useful for writing confidence tests that
-execute quickly and don't rely on outside files.
-
-The mesh is made by a few vertices on the line segment from (1,0,0) to (1,1,0) and a few dummy
-faces. The skeleton has three joints: root at (0,0,0), joint1 parented by root, at world-space
-(0,1,0), and joint2 parented by joint1, at world-space (0,2,0).
-The character has only one parameter limit: min-max type [-0.1, 0.1] for root.
-
-:parameter numJoints: The number of joints in the resulting character.
-:return: A simple character with 3 joints and 10 model parameters.
-      )",
-      py::arg("num_joints") = 3);
-
-  // createTestPosePrior()
-  m.def(
-      "create_test_mppca",
-      &momentum::createDefaultPosePrior<float>,
-      R"(Create a pose prior that acts on the simple 3-joint test character.
-
-:return: A simple pose prior.)");
 
   // uniformRandomToModelParameters(character, unifNoise)
   m.def(

--- a/pymomentum/geometry/geometry_test_helper_pybind.cpp
+++ b/pymomentum/geometry/geometry_test_helper_pybind.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <momentum/test/character/character_helpers.h>
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+namespace mm = momentum;
+
+PYBIND11_MODULE(geometry_test_helper, m) {
+  m.doc() = "Geometry test helper.  ";
+  m.attr("__name__") = "pymomentum.geometry_test_helper";
+
+  pybind11::module_::import(
+      "pymomentum.geometry"); // @dep=fbcode//pymomentum:geometry
+
+  // createTestCharacter()
+  m.def(
+      "test_character",
+      &momentum::createTestCharacter<float>,
+      R"(Create a simple 3-joint test character.  This is useful for writing confidence tests that
+execute quickly and don't rely on outside files.
+
+The mesh is made by a few vertices on the line segment from (1,0,0) to (1,1,0) and a few dummy
+faces. The skeleton has three joints: root at (0,0,0), joint1 parented by root, at world-space
+(0,1,0), and joint2 parented by joint1, at world-space (0,2,0).
+The character has only one parameter limit: min-max type [-0.1, 0.1] for root.
+
+:parameter numJoints: The number of joints in the resulting character.
+:return: A simple character with 3 joints and 10 model parameters.
+      )",
+      py::arg("num_joints") = 3);
+
+  // createTestPosePrior()
+  m.def(
+      "create_test_mppca",
+      &momentum::createDefaultPosePrior<float>,
+      R"(Create a pose prior that acts on the simple 3-joint test character.
+
+:return: A simple pose prior.)");
+}

--- a/pymomentum/test/test_parameter_transform.py
+++ b/pymomentum/test/test_parameter_transform.py
@@ -8,11 +8,8 @@
 import unittest
 
 import torch
-from pymomentum.geometry import (
-    Character,
-    test_character,
-    uniform_random_to_model_parameters,
-)
+from pymomentum.geometry import Character, uniform_random_to_model_parameters
+from pymomentum.geometry_test_helper import test_character
 
 
 class TestParameterTransform(unittest.TestCase):

--- a/pymomentum/test/test_skel_state.py
+++ b/pymomentum/test/test_skel_state.py
@@ -8,6 +8,7 @@
 import unittest
 
 import pymomentum.geometry as pym_geometry
+import pymomentum.geometry_test_helper as pym_geometry_test_helper
 import pymomentum.quaternion as quaternion
 import pymomentum.skel_state as skel_state
 import torch
@@ -43,7 +44,7 @@ def generateRandomSkelState(sz):
 
 class TestSkelState(unittest.TestCase):
     def test_skelStateToTransforms(self) -> None:
-        character = pym_geometry.test_character()
+        character = pym_geometry_test_helper.test_character()
         nBatch = 2
         modelParams = 0.2 * torch.ones(
             nBatch,

--- a/pymomentum/test/test_skeleton.py
+++ b/pymomentum/test/test_skeleton.py
@@ -7,7 +7,8 @@
 
 import unittest
 
-from pymomentum.geometry import Character, test_character
+from pymomentum.geometry import Character
+from pymomentum.geometry_test_helper import test_character
 
 
 class TestSkeleton(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ def main():
         ext_modules=[
             CMakeExtension("geometry", sourcedir=ROOT_DIR),
             CMakeExtension("quaternion", sourcedir=ROOT_DIR),
+            CMakeExtension("geometry_test_helper", sourcedir=ROOT_DIR),
             CMakeExtension("skel_state", sourcedir=ROOT_DIR),
         ],
         cmdclass={


### PR DESCRIPTION
Summary: The `pymomentum.geometry` module contains the `momentum.character_test_helper`, which has `gtest` as a dependency. This change removes the `gtest` dependency from the pymomentum core module by moving the test functions to a new module called `geometry_test_helper` (open to suggestions for a better name).

Differential Revision: D63378477


