### PR TITLE
Dynamic alignment computation for SIMD error functions

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -14,8 +14,18 @@ on:
 
 jobs:
   momentum:
-    name: momentum-ubuntu
+    name: momentum-simd:${{ matrix.simd }}-ubuntu
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - simd: "ON"
+            pymomentum: "ON"
+          - simd: "OFF"
+            pymomentum: "OFF"
+    env:
+      MOMENTUM_ENABLE_SIMD: ${{ matrix.simd }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,10 +35,14 @@ jobs:
           cache: true
       - name: Build and test Momentum
         run: |
-          pixi run test
+          MOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
+            MOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
+            pixi run test
       - name: Install Momentum and Build hello_world
         run: |
-          pixi run install
+          MOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
+            MOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
+            pixi run install
           pixi run cmake \
             -S momentum/examples/hello_world \
             -B momentum/examples/hello_world/build \

--- a/cmake/mt_defs.cmake
+++ b/cmake/mt_defs.cmake
@@ -251,6 +251,9 @@ function(mt_library)
     else()
       target_compile_options(${_ARG_NAME} ${type} -march=native)
     endif()
+    target_compile_definitions(${_ARG_NAME}
+      ${type} -DMOMENTUM_ENABLE_SIMD=1
+    )
   endif()
   target_compile_options(${_ARG_NAME}
     ${type} ${_ARG_PUBLIC_COMPILE_OPTIONS}

--- a/momentum/character_solver/simd_normal_error_function.h
+++ b/momentum/character_solver/simd_normal_error_function.h
@@ -101,7 +101,7 @@ class SimdNormalErrorFunction : public SkeletonErrorFunction {
       Ref<VectorXf> residual,
       int& usedRows) override;
 
-  [[nodiscard]] size_t getJacobianSize() const final;
+  [[nodiscard]] size_t getJacobianSize() const override;
 
   void setConstraints(const SimdNormalConstraints* cstrs) {
     constraints_ = cstrs;
@@ -120,6 +120,7 @@ class SimdNormalErrorFunction : public SkeletonErrorFunction {
 };
 
 #ifdef MOMENTUM_ENABLE_AVX
+
 // A version of SimdNormalErrorFunction where the Jacobian has been hand-unrolled using
 // AVX instructions.  On some platforms this performs better than the generic SIMD version
 // but it only works on Intel platforms that support AVX.
@@ -141,7 +142,10 @@ class SimdNormalErrorFunctionAVX : public SimdNormalErrorFunction {
       Ref<MatrixXf> jacobian,
       Ref<VectorXf> residual,
       int& usedRows) final;
+
+  [[nodiscard]] size_t getJacobianSize() const final;
 };
+
 #endif // MOMENTUM_ENABLE_AVX
 
 } // namespace momentum

--- a/momentum/character_solver/simd_plane_error_function.cpp
+++ b/momentum/character_solver/simd_plane_error_function.cpp
@@ -26,28 +26,15 @@
 
 namespace momentum {
 
-namespace {
-
-template <typename Derived>
-void ensureAligned(const Eigen::MatrixBase<Derived>& mat, size_t& addressOffset) {
-  if (addressOffset == 8)
-    addressOffset = 0;
-  MT_CHECK(((uintptr_t)(&mat(addressOffset, 0))) % 32 == 0);
-}
-
-} // namespace
-
 SimdPlaneConstraints::SimdPlaneConstraints(const Skeleton* skel) {
-  constexpr uintptr_t kAlignment = 32;
-
   // resize all arrays to the number of joints
   MT_CHECK(skel->joints.size() <= kMaxJoints);
   numJoints = static_cast<int>(skel->joints.size());
   const auto dataSize = kMaxConstraints * numJoints;
-  MT_CHECK(dataSize % kAlignment == 0);
+  MT_CHECK(dataSize % kSimdAlignment == 0);
 
   // create memory for all floats
-  data = makeAlignedUnique<float, kAlignment>(dataSize * 8);
+  data = makeAlignedUnique<float, kSimdAlignment>(dataSize * 8);
   float* dataPtr = data.get();
 
   offsetX = dataPtr + dataSize * 0;
@@ -161,7 +148,7 @@ double SimdPlaneErrorFunction::getError(
     }
   }
 
-  // Sum the AVX error register for final result
+  // Sum the SIMD error register for final result
   return static_cast<float>(drjit::sum(error) * kPlaneWeight * weight_);
 }
 
@@ -176,9 +163,8 @@ double SimdPlaneErrorFunction::getGradient(
   // Storage for joint errors
   std::vector<double> jointErrors(constraints_->numJoints);
 
-  // Need to make sure we're actually at a 32 byte data offset at the first offset for AVX access
-  size_t addressOffset = 8 - (((size_t)gradient.data() % 32) / 4);
-  ensureAligned(gradient, addressOffset);
+  // Need to make sure we're actually at a 32 byte data offset at the first offset for SIMD access
+  checkAlignment<kSimdAlignment>(gradient);
 
   // Loop over all joints, as these are our base units
   auto dispensoOptions = dispenso::ParForOptions();
@@ -331,9 +317,8 @@ double SimdPlaneErrorFunction::getJacobian(
   // Storage for joint errors
   std::vector<double> jointErrors(constraints_->numJoints);
 
-  // Need to make sure we're actually at a 32 byte data offset at the first offset for avx access
-  size_t addressOffset = 8 - (((size_t)jacobian.data() % 32) / 4);
-  ensureAligned(jacobian, addressOffset);
+  // Need to make sure we're actually at a 32 byte data offset at the first offset for SIMD access
+  checkAlignment<kSimdAlignment>(jacobian);
 
   // Loop over all joints, as these are our base units
   auto dispensoOptions = dispenso::ParForOptions();
@@ -455,11 +440,11 @@ size_t SimdPlaneErrorFunction::getJacobianSize() const {
   size_t num = 0;
   for (int i = 0; i < constraints_->numJoints; i++) {
     jacobianOffset_[i] = num;
-    const auto numPackets =
-        (constraints_->constraintCount[i] + kSimdPacketSize - 1) / kSimdPacketSize;
+    const size_t count = constraints_->constraintCount[i];
+    const auto numPackets = (count + kSimdPacketSize - 1) / kSimdPacketSize;
     num += numPackets * kSimdPacketSize;
   }
-  return num + kSimdPacketSize;
+  return num;
 }
 
 void SimdPlaneErrorFunction::setConstraints(const SimdPlaneConstraints* cstrs) {
@@ -517,9 +502,9 @@ double SimdPlaneErrorFunctionAVX::getError(
 
     const auto jointOffset = jointId * SimdPlaneConstraints::kMaxConstraints;
 
-    // loop over all constraints in increments of 8
+    // loop over all constraints in increments of kAvxPacketSize
     const uint32_t count = constraints_->constraintCount[jointId];
-    for (uint32_t index = 0; index < count; index += 8) {
+    for (uint32_t index = 0; index < count; index += kAvxPacketSize) {
       // transform offset by joint transformation :           pos = transform * offset
       const __m256 valx = _mm256_loadu_ps(&constraints_->offsetX[jointOffset + index]);
       posx = _mm256_mul_ps(valx, _mm256_broadcast_ss(&transformation.data()[0]));
@@ -557,7 +542,7 @@ double SimdPlaneErrorFunctionAVX::getError(
     }
   }
 
-  // sum the avx error register for final result
+  // sum the AVX error register for final result
   return static_cast<float>(error * kPlaneWeight * weight_);
 }
 
@@ -596,9 +581,9 @@ double SimdPlaneErrorFunctionAVX::getGradient(
 
         const auto jointOffset = jointId * SimdPlaneConstraints::kMaxConstraints;
 
-        // loop over all constraints in increments of 8
+        // loop over all constraints in increments of kAvxPacketSize
         const uint32_t count = constraints_->constraintCount[jointId];
-        for (uint32_t index = 0; index < count; index += 8) {
+        for (uint32_t index = 0; index < count; index += kAvxPacketSize) {
           // transform offset by joint transformation :           pos = transform * offset
           const __m256 valx = _mm256_loadu_ps(&constraints_->offsetX[jointOffset + index]);
           posx = _mm256_mul_ps(valx, _mm256_broadcast_ss(&transformation.data()[0]));
@@ -753,7 +738,7 @@ double SimdPlaneErrorFunctionAVX::getGradient(
 
     // finalize the gradient
     gradient += std::get<1>(ets_error_grad[0]).cast<float>() * weight_;
-    // sum the avx error register for final result
+    // sum the AVX error register for final result
     error = std::get<0>(ets_error_grad[0]);
   }
 
@@ -776,18 +761,17 @@ double SimdPlaneErrorFunctionAVX::getJacobian(
   // storage for joint errors
   std::vector<double> ets_error;
 
-  // need to make sure we're actually at a 32 byte data offset at the first offset for avx access
-  size_t addressOffset = 8 - (((size_t)jacobian.data() % 32) / 4);
-  ensureAligned(jacobian, addressOffset);
+  // need to make sure we're actually at a 32 byte data offset at the first offset for AVX access
+  checkAlignment<kAvxAlignment>(jacobian);
 
   // calculate actually used number of rows
   const size_t maxRows = gsl::narrow_cast<size_t>(jacobian.rows());
   size_t num = 0;
   for (int i = 0; i < constraints_->numJoints; i++) {
     jacobianOffset_[i] = num;
-    const size_t res = constraints_->constraintCount[i] % 8;
+    const size_t res = constraints_->constraintCount[i] % kAvxPacketSize;
     if (res != 0) {
-      num += constraints_->constraintCount[i] + 8 - res;
+      num += constraints_->constraintCount[i] + kAvxPacketSize - res;
     } else {
       num += constraints_->constraintCount[i];
     }
@@ -803,7 +787,7 @@ double SimdPlaneErrorFunctionAVX::getJacobian(
       constraints_->numJoints,
       [&](double& error_local, const size_t jointId) {
         // get initial offset
-        const auto offset = jacobianOffset_[jointId] + addressOffset;
+        const auto offset = jacobianOffset_[jointId];
 
         // pre-load some joint specific values
         const auto& transformation = state.jointState[jointId].transformation;
@@ -815,12 +799,13 @@ double SimdPlaneErrorFunctionAVX::getJacobian(
 
         const auto jointOffset = jointId * SimdPlaneConstraints::kMaxConstraints;
 
-        // loop over all constraints in increments of 8
+        // loop over all constraints in increments of kAvxPacketSize
         const uint32_t count = constraints_->constraintCount[jointId];
-        for (uint32_t index = 0; index < count; index += 8) {
+        for (uint32_t index = 0; index < count; index += kAvxPacketSize) {
           // check if we're too much
-          if (offset + index + 8 >= maxRows)
+          if (offset + index + kAvxPacketSize >= maxRows) {
             continue;
+          }
 
           // transform offset by joint transformation: pos = transform * offset
           const __m256 valx = _mm256_loadu_ps(&constraints_->offsetX[jointOffset + index]);
@@ -978,13 +963,30 @@ double SimdPlaneErrorFunctionAVX::getJacobian(
 
   double error = std::accumulate(ets_error.begin(), ets_error.end(), 0.0);
 
-  if (addressOffset + num >= maxRows)
+  if (num >= maxRows) {
     usedRows = gsl::narrow_cast<int>(maxRows - 1);
-  else
-    usedRows = gsl::narrow_cast<int>(addressOffset + num);
+  } else {
+    usedRows = gsl::narrow_cast<int>(num);
+  }
 
-  // sum the avx error register for final result
+  // sum the AVX error register for final result
   return static_cast<float>(error);
+}
+
+size_t SimdPlaneErrorFunctionAVX::getJacobianSize() const {
+  if (constraints_ == nullptr) {
+    return 0;
+  }
+
+  jacobianOffset_.resize(constraints_->numJoints);
+  size_t num = 0;
+  for (int i = 0; i < constraints_->numJoints; i++) {
+    jacobianOffset_[i] = num;
+    const size_t count = constraints_->constraintCount[i];
+    const auto numPackets = (count + kAvxPacketSize - 1) / kAvxPacketSize;
+    num += numPackets * kAvxPacketSize;
+  }
+  return num;
 }
 
 #endif // MOMENTUM_ENABLE_AVX

--- a/momentum/character_solver/simd_plane_error_function.h
+++ b/momentum/character_solver/simd_plane_error_function.h
@@ -100,7 +100,7 @@ class SimdPlaneErrorFunction : public SkeletonErrorFunction {
       Ref<VectorXf> residual,
       int& usedRows) override;
 
-  [[nodiscard]] size_t getJacobianSize() const final;
+  [[nodiscard]] size_t getJacobianSize() const override;
 
   void setConstraints(const SimdPlaneConstraints* cstrs);
 
@@ -145,6 +145,8 @@ class SimdPlaneErrorFunctionAVX : public SimdPlaneErrorFunction {
       Ref<MatrixXf> jacobian,
       Ref<VectorXf> residual,
       int& usedRows) final;
+
+  [[nodiscard]] size_t getJacobianSize() const final;
 };
 
 #endif // MOMENTUM_ENABLE_AVX

--- a/momentum/character_solver/simd_position_error_function.h
+++ b/momentum/character_solver/simd_position_error_function.h
@@ -67,6 +67,9 @@ struct SimdPositionConstraints final {
 /// results may be produced on multiple calls with the same data.
 class SimdPositionErrorFunction : public SkeletonErrorFunction {
  public:
+  /// The dimensionality of each constraint.
+  static constexpr size_t kConstraintDim = 3;
+
   /// @param maxThreads An optional parameter that specifies the maximum number of threads to be
   /// used with dispenso::parallel_for. If this parameter is set to zero, the function will run in
   /// serial mode, i.e., it will not use any additional threads. By default, the value is set to the
@@ -98,7 +101,7 @@ class SimdPositionErrorFunction : public SkeletonErrorFunction {
       Ref<VectorXf> residual,
       int& usedRows) override;
 
-  [[nodiscard]] size_t getJacobianSize() const final;
+  [[nodiscard]] size_t getJacobianSize() const override;
 
   void setConstraints(const SimdPositionConstraints* cstrs);
 
@@ -143,6 +146,8 @@ class SimdPositionErrorFunctionAVX : public SimdPositionErrorFunction {
       Ref<MatrixXf> jacobian,
       Ref<VectorXf> residual,
       int& usedRows) final;
+
+  [[nodiscard]] size_t getJacobianSize() const final;
 };
 
 #endif // MOMENTUM_ENABLE_AVX

--- a/momentum/simd/simd.h
+++ b/momentum/simd/simd.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <momentum/common/exception.h>
+
 #include <drjit/array.h>
 #include <drjit/array_router.h>
 #include <drjit/packet.h>
@@ -19,8 +21,11 @@
 
 namespace momentum {
 
+inline constexpr size_t kAvxPacketSize = 8;
+inline constexpr size_t kAvxAlignment = kAvxPacketSize * sizeof(float);
+
 inline constexpr size_t kSimdPacketSize = drjit::DefaultSize;
-inline constexpr size_t kSimdAlignment = kSimdPacketSize * 4;
+inline constexpr size_t kSimdAlignment = kSimdPacketSize * sizeof(float);
 
 template <typename T>
 using Packet = drjit::Packet<T, kSimdPacketSize>;
@@ -43,6 +48,18 @@ using Vector3fP = Vector3P<float>;
 
 using Vector2dP = Vector2P<double>;
 using Vector3dP = Vector3P<double>;
+
+/// Checks if the data of the matrix is aligned correctly.
+template <size_t Alignment>
+void checkAlignment(const Eigen::Ref<Eigen::MatrixXf>& mat) {
+  MT_THROW_IF(
+      (uintptr_t(mat.data())) % Alignment != 0,
+      "Matrix ({}x{}, ptr: {}) is not aligned ({}) correctly.",
+      mat.rows(),
+      mat.cols(),
+      uintptr_t(mat.data()),
+      Alignment);
+}
 
 /// Calculates dot product of Eigen::Vector3f and 3-vector of packets.
 ///

--- a/momentum/test/character_solver/error_function_helpers.cpp
+++ b/momentum/test/character_solver/error_function_helpers.cpp
@@ -14,6 +14,7 @@
 #include "momentum/character_solver/skeleton_error_function.h"
 #include "momentum/common/log.h"
 #include "momentum/math/fmt_eigen.h"
+#include "momentum/simd/simd.h"
 
 namespace momentum {
 
@@ -224,7 +225,7 @@ void validateIdentical(
     const auto n = transform.numAllModelParameters();
     const size_t m1 = err1.getJacobianSize();
     const size_t m2 = err2.getJacobianSize();
-    EXPECT_LE(m1, m2); // SIMD pads out to a multiple of 8.
+    EXPECT_LE(m1, m2); // SIMD pads out to a multiple of kSimdPacketSize.
 
     Eigen::MatrixX<T> j1 = Eigen::MatrixX<T>::Zero(m1, n);
     Eigen::MatrixX<T> j2 = Eigen::MatrixX<T>::Zero(m2, n);
@@ -267,7 +268,8 @@ void timeJacobian(
     const ModelParameters& modelParams,
     const char* type) {
   const size_t jacobianSize = errorFunction.getJacobianSize();
-  const size_t paddedJacobianSize = jacobianSize + 8 - (jacobianSize % 8);
+  const size_t paddedJacobianSize =
+      jacobianSize + kSimdPacketSize - (jacobianSize % kSimdPacketSize);
   Eigen::MatrixXf jacobian = Eigen::MatrixXf::Zero(
       paddedJacobianSize, character.parameterTransform.numAllModelParameters());
   Eigen::VectorXf residual = Eigen::VectorXf::Zero(paddedJacobianSize);

--- a/momentum/test/character_solver/simd_functions_test.cpp
+++ b/momentum/test/character_solver/simd_functions_test.cpp
@@ -46,7 +46,19 @@ TEST(Momentum_ErrorFunctions, SimdNormalFunctionIsSame) {
   const ParameterTransform& transform = character.parameterTransform;
 
   SimdNormalConstraints cl_simd(&skeleton);
-  for (size_t nConstraints : {0, 1, 2, 5, 15}) {
+  const std::initializer_list<size_t> constraints = {
+      0ul,
+      1ul,
+      kAvxPacketSize - 1,
+      kAvxPacketSize,
+      kAvxPacketSize + 1,
+      kAvxPacketSize * 2,
+      kSimdPacketSize - 1,
+      kSimdPacketSize,
+      kSimdPacketSize + 1,
+      kSimdPacketSize * 2,
+      100ul};
+  for (size_t nConstraints : constraints) {
     const auto parameters = uniform<VectorXf>(transform.numAllModelParameters(), -0.5, 0.5);
 
     std::vector<NormalData> cl;
@@ -96,7 +108,19 @@ TEST(Momentum_ErrorFunctions, SimdPositionFunctionIsSame) {
   const ParameterTransform& transform = character.parameterTransform;
 
   SimdPositionConstraints cl_simd(&skeleton);
-  for (size_t nConstraints : {0, 1, 2, 5, 15}) {
+  const std::initializer_list<size_t> constraints = {
+      0ul,
+      1ul,
+      kAvxPacketSize - 1,
+      kAvxPacketSize,
+      kAvxPacketSize + 1,
+      kAvxPacketSize * 2,
+      kSimdPacketSize - 1,
+      kSimdPacketSize,
+      kSimdPacketSize + 1,
+      kSimdPacketSize * 2,
+      100ul};
+  for (size_t nConstraints : constraints) {
     if (verbose) {
       fmt::print("nConstraints: {}\n", nConstraints);
     }
@@ -150,7 +174,19 @@ TEST(Momentum_ErrorFunctions, SimdPlaneFunctionIsSame) {
   const ParameterTransform& transform = character.parameterTransform;
 
   SimdPlaneConstraints cl_simd(&skeleton);
-  for (size_t nConstraints : {0, 1, 2, 5, 15, 100}) {
+  const std::initializer_list<size_t> constraints = {
+      0ul,
+      1ul,
+      kAvxPacketSize - 1,
+      kAvxPacketSize,
+      kAvxPacketSize + 1,
+      kAvxPacketSize * 2,
+      kSimdPacketSize - 1,
+      kSimdPacketSize,
+      kSimdPacketSize + 1,
+      kSimdPacketSize * 2,
+      100ul};
+  for (size_t nConstraints : constraints) {
     const auto parameters = uniform<VectorXf>(transform.numAllModelParameters(), -0.5, 0.5);
 
     std::vector<PlaneData> cl;
@@ -202,7 +238,10 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, SimdCollisionErrorFunctionIsSame) {
 
   CollisionErrorFunctionT<T> errf_base(character);
   CollisionErrorFunctionStatelessT<T> errf_stateless(character);
+  // TODO: Fix this test for SIMD when MOMENTUM_ENABLE_SIMD=OFF
+#ifdef MOMENTUM_ENABLE_SIMD
   SimdCollisionErrorFunctionT<T> errf_simd(character);
+#endif
 
   const size_t nBendTests = 8;
   for (size_t iBendAmount = 4; iBendAmount < nBendTests; ++iBendAmount) {
@@ -221,11 +260,17 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, SimdCollisionErrorFunctionIsSame) {
 
     const double err_base = errf_base.getError(mp, skelState);
     const double err_stateless = errf_stateless.getError(mp, skelState);
+#ifdef MOMENTUM_ENABLE_SIMD
     const double err_simd = errf_simd.getError(mp, skelState);
+#endif
     ASSERT_NEAR(err_base, err_stateless, 0.0001 * err_base);
+#ifdef MOMENTUM_ENABLE_SIMD
     ASSERT_NEAR(err_base, err_simd, 0.0001 * err_base);
+#endif
     VALIDATE_IDENTICAL(T, errf_base, errf_stateless, skeleton, transform, mp.v);
+#ifdef MOMENTUM_ENABLE_SIMD
     VALIDATE_IDENTICAL(T, errf_base, errf_simd, skeleton, transform, mp.v);
+#endif
   }
 
   MT_LOGI("done.");

--- a/pixi.toml
+++ b/pixi.toml
@@ -43,9 +43,21 @@ spdlog = ">=1.12.0,<1.13"
 
 [tasks]
 clean = { cmd = "rm -rf build && rm -rf .pixi && rm pixi.lock" }
-configure = { cmd = "cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON -DMOMENTUM_USE_SYSTEM_PYBIND11=ON -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON -DMOMENTUM_BUILD_TESTING=ON -DMOMENTUM_BUILD_EXAMPLES=ON -DMOMENTUM_BUILD_PYMOMENTUM=ON", inputs = [
-    "CMakeLists.txt",
-] }
+configure = { cmd = """
+    cmake \
+        -S . \
+        -B build \
+        -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DMOMENTUM_BUILD_TESTING=ON \
+        -DMOMENTUM_BUILD_EXAMPLES=ON \
+        -DMOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
+        -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
+        -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
+        -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
+        -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
+    """, env = { MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
 build = { cmd = "cmake --build build -j --target all", depends_on = [
     "configure",
 ] }
@@ -76,7 +88,15 @@ sysroot_linux-64 = ">=2.28"
 [target.linux-64.tasks]
 lint = { cmd = "clang-format-18 -i axel/**/*.h axel/**/*.cpp momentum/**/*.h momentum/**/*.cpp pymomentum/**/*.h pymomentum/**/*.cpp" }
 build_pymomentum = { cmd = "pip install -e ." }
-test_pymomentum = { cmd = "pytest pymomentum/test/test_closest_points.py pymomentum/test/test_fbx.py pymomentum/test/test_parameter_transform.py pymomentum/test/test_quaternion.py pymomentum/test/test_skel_state.py pymomentum/test/test_skeleton.py", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends_on = [
+test_pymomentum = { cmd = """
+    pytest \
+        pymomentum/test/test_closest_points.py \
+        pymomentum/test/test_fbx.py \
+        pymomentum/test/test_parameter_transform.py \
+        pymomentum/test/test_quaternion.py \
+        pymomentum/test/test_skel_state.py \
+        pymomentum/test/test_skeleton.py
+    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends_on = [
     "build_pymomentum",
 ] }
 
@@ -123,9 +143,22 @@ build_pymomentum = { cmd = "pip install -e ." }
 [target.win-64.dependencies]
 
 [target.win-64.tasks]
-configure = { cmd = "cmake -S . -B build -G 'Visual Studio 17 2022' -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_SHARED_LIBS=OFF -DMOMENTUM_BUILD_IO_FBX=ON -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON -DMOMENTUM_USE_SYSTEM_PYBIND11=ON -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON -DMOMENTUM_BUILD_TESTING=ON -DMOMENTUM_BUILD_EXAMPLES=ON -DMOMENTUM_BUILD_PYMOMENTUM=OFF", inputs = [
-    "CMakeLists.txt",
-] }
+configure = { cmd = """
+    cmake \
+        -S . \
+        -B build \
+        -G 'Visual Studio 17 2022' \
+        -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DMOMENTUM_BUILD_EXAMPLES=ON \
+        -DMOMENTUM_BUILD_IO_FBX=ON \
+        -DMOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
+        -DMOMENTUM_BUILD_TESTING=ON \
+        -DMOMENTUM_ENABLE_SIMD=%MOMENTUM_ENABLE_SIMD% \
+        -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
+        -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
+        -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
+    """, env = { MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "OFF" } }
 open_vs = { cmd = "cmd /c start build\\momentum.sln", depends_on = [
     "configure",
 ] }


### PR DESCRIPTION
Summary:
Previously, a static alignment value of 32 was used for AVX in SIMD implementations. This diff modifies this approach to dynamically determine the correct alignment value via Enoki at compile-time, ensuring compatibility across different SIMD instruction sets.

NOTE: This Diff the second trial of D47103616

Differential Revision: D63658278


