### PR TITLE
Make SkeletonSolverFunction take error function as shared_ptr

### DIFF
--- a/momentum/character_solver/skeleton_solver_function.cpp
+++ b/momentum/character_solver/skeleton_solver_function.cpp
@@ -87,7 +87,7 @@ double SkeletonSolverFunctionT<T>::getGradient(
 
 template <typename T>
 std::pair<size_t, std::vector<size_t>> getDimensions(
-    const std::vector<SkeletonErrorFunctionT<T>*>& error_func) {
+    const std::vector<std::shared_ptr<SkeletonErrorFunctionT<T>>>& error_func) {
   MT_PROFILE_EVENT("GetJacobianSize");
   std::vector<size_t> offset(error_func.size());
   size_t jacobianSize = 0;
@@ -285,8 +285,9 @@ void SkeletonSolverFunctionT<T>::updateParameters(
 }
 
 template <typename T>
-void SkeletonSolverFunctionT<T>::addErrorFunction(SkeletonErrorFunctionT<T>* errorFunction) {
-  errorFunctions_.push_back(errorFunction);
+void SkeletonSolverFunctionT<T>::addErrorFunction(
+    std::shared_ptr<SkeletonErrorFunctionT<T>> solvable) {
+  errorFunctions_.push_back(std::move(solvable));
 }
 
 template <typename T>
@@ -295,8 +296,8 @@ void SkeletonSolverFunctionT<T>::clearErrorFunctions() {
 }
 
 template <typename T>
-const std::vector<SkeletonErrorFunctionT<T>*>& SkeletonSolverFunctionT<T>::getErrorFunctions()
-    const {
+const std::vector<std::shared_ptr<SkeletonErrorFunctionT<T>>>&
+SkeletonSolverFunctionT<T>::getErrorFunctions() const {
   return errorFunctions_;
 }
 

--- a/momentum/character_solver/skeleton_solver_function.h
+++ b/momentum/character_solver/skeleton_solver_function.h
@@ -44,10 +44,11 @@ class SkeletonSolverFunctionT : public SolverFunctionT<T> {
   void updateParameters(Eigen::VectorX<T>& parameters, const Eigen::VectorX<T>& delta) final;
   void setEnabledParameters(const ParameterSet& ps) final;
 
-  void addErrorFunction(SkeletonErrorFunctionT<T>* solvable);
+  void addErrorFunction(std::shared_ptr<SkeletonErrorFunctionT<T>> solvable);
   void clearErrorFunctions();
 
-  const std::vector<SkeletonErrorFunctionT<T>*>& getErrorFunctions() const;
+  [[nodiscard]] const std::vector<std::shared_ptr<SkeletonErrorFunctionT<T>>>& getErrorFunctions()
+      const;
 
   const Skeleton* getSkeleton() {
     return skeleton_;
@@ -65,7 +66,7 @@ class SkeletonSolverFunctionT : public SolverFunctionT<T> {
   Eigen::MatrixX<T> tJacobian_;
   Eigen::VectorX<T> tResidual_;
 
-  std::vector<SkeletonErrorFunctionT<T>*> errorFunctions_;
+  std::vector<std::shared_ptr<SkeletonErrorFunctionT<T>>> errorFunctions_;
 };
 
 } // namespace momentum

--- a/momentum/character_solver/transform_pose.cpp
+++ b/momentum/character_solver/transform_pose.cpp
@@ -131,13 +131,14 @@ std::vector<ModelParametersT<T>> transformPose(
     simplifiedParamToFullParamIdx.at(iSimplifiedParam) = fullParamIdx;
   }
 
-  momentum::PositionErrorFunctionT<T> positionError(characterSimplified);
-  momentum::OrientationErrorFunctionT<T> orientationError(characterSimplified);
+  auto positionError = std::make_shared<momentum::PositionErrorFunctionT<T>>(characterSimplified);
+  auto orientationError =
+      std::make_shared<momentum::OrientationErrorFunctionT<T>>(characterSimplified);
 
   momentum::SkeletonSolverFunctionT<T> solverFunction(
       &characterSimplified.skeleton, &parameterTransformSimplified);
-  solverFunction.addErrorFunction(&positionError);
-  solverFunction.addErrorFunction(&orientationError);
+  solverFunction.addErrorFunction(positionError);
+  solverFunction.addErrorFunction(orientationError);
 
   momentum::GaussNewtonSolverOptions solverOptions;
   solverOptions.maxIterations = 1000;
@@ -173,12 +174,12 @@ std::vector<ModelParametersT<T>> transformPose(
     const Eigen::Quaternion<T> worldFromRootRotationTarget =
         transform.rotation * skelStateFull.jointState[rootJointFull].rotation();
 
-    positionError.clearConstraints();
-    positionError.addConstraint(PositionDataT<T>(
+    positionError->clearConstraints();
+    positionError->addConstraint(PositionDataT<T>(
         Eigen::Vector3<T>::Zero(), worldFromRootTranslationTarget, rootJointSimplified, 100.0));
 
-    orientationError.clearConstraints();
-    orientationError.addConstraint(OrientationDataT<T>(
+    orientationError->clearConstraints();
+    orientationError->addConstraint(OrientationDataT<T>(
         Eigen::Quaternion<T>::Identity(), worldFromRootRotationTarget, rootJointSimplified, 10.0));
 
     // Initialize with rest params

--- a/momentum/diff_ik/fully_differentiable_body_ik.cpp
+++ b/momentum/diff_ik/fully_differentiable_body_ik.cpp
@@ -217,7 +217,8 @@ std::vector<ErrorFunctionDerivativesT<T>> d_modelParams_d_inputs(
     result[iErr].errorFunction = errf;
     result[iErr].gradWeight = -dGrad_dWeight.dot(Jinv_times_dLoss_dModelParams_full);
 
-    auto differentiableErr = dynamic_cast<FullyDifferentiableSkeletonErrorFunctionT<T>*>(errf);
+    auto differentiableErr =
+        std::dynamic_pointer_cast<FullyDifferentiableSkeletonErrorFunctionT<T>>(errf);
     if (differentiableErr != nullptr) {
       for (const auto& inputName : differentiableErr->inputs()) {
         result[iErr].gradInputs.emplace(

--- a/momentum/diff_ik/fully_differentiable_body_ik.h
+++ b/momentum/diff_ik/fully_differentiable_body_ik.h
@@ -28,7 +28,7 @@ namespace momentum {
 
 template <typename T>
 struct ErrorFunctionDerivativesT {
-  const SkeletonErrorFunctionT<T>* errorFunction = nullptr;
+  std::shared_ptr<const SkeletonErrorFunctionT<T>> errorFunction = nullptr;
 
   // Gradient of the energy wrt the global weight.
   T gradWeight = 0;

--- a/momentum/marker_tracking/marker_tracker.cpp
+++ b/momentum/marker_tracking/marker_tracker.cpp
@@ -213,12 +213,12 @@ Eigen::MatrixXf trackPosesPerframe(
   // parameter limits constraint
   auto limitConstrFunc = std::make_shared<LimitErrorFunction>(character);
   limitConstrFunc->setWeight(0.1);
-  solverFunc.addErrorFunction(limitConstrFunc.get());
+  solverFunc.addErrorFunction(limitConstrFunc);
 
   // positional constraint function for markers
   auto posConstrFunc = std::make_shared<PositionErrorFunction>(character, config.lossAlpha);
   posConstrFunc->setWeight(PositionErrorFunction::kLegacyWeight);
-  solverFunc.addErrorFunction(posConstrFunc.get());
+  solverFunc.addErrorFunction(posConstrFunc);
 
   // floor penetration constraint data; we assume the world is y-up and floor is y=0 for mocap data.
   const auto& floorConstraints = createFloorConstraints<float>(
@@ -230,7 +230,7 @@ Eigen::MatrixXf trackPosesPerframe(
   auto halfPlaneConstrFunc = std::make_shared<PlaneErrorFunction>(character, /*half plane*/ true);
   halfPlaneConstrFunc->setConstraints(floorConstraints);
   halfPlaneConstrFunc->setWeight(PlaneErrorFunction::kLegacyWeight);
-  solverFunc.addErrorFunction(halfPlaneConstrFunc.get());
+  solverFunc.addErrorFunction(halfPlaneConstrFunc);
 
   // marker constraint data
   auto constrData = createConstraintData(markerData, character.locators);
@@ -240,18 +240,18 @@ Eigen::MatrixXf trackPosesPerframe(
   auto smoothConstrFunc = std::make_shared<ModelParametersErrorFunction>(
       character, poseParams & ~pt.getRigidParameters());
   smoothConstrFunc->setWeight(config.smoothing);
-  solverFunc.addErrorFunction(smoothConstrFunc.get());
+  solverFunc.addErrorFunction(smoothConstrFunc);
 
   // add collision error
   std::shared_ptr<CollisionErrorFunction> collisionErrorFunction;
   if (config.collisionErrorWeight != 0 && character.collision != nullptr) {
     collisionErrorFunction = std::make_shared<CollisionErrorFunction>(character);
     collisionErrorFunction->setWeight(config.collisionErrorWeight);
-    solverFunc.addErrorFunction(collisionErrorFunction.get());
+    solverFunc.addErrorFunction(collisionErrorFunction);
   }
 
   MatrixXf motion(pt.numAllModelParameters(), numFrames);
-  // initialze parameters to contain identity information
+  // initialize parameters to contain identity information
   // the identity fields will be used but untouched during optimization
   // globalParams could also be repurposed to pass in initial pose value
   Eigen::VectorXf dof = globalParams.v;

--- a/momentum/test/character_solver/blend_shape_test.cpp
+++ b/momentum/test/character_solver/blend_shape_test.cpp
@@ -157,11 +157,11 @@ TYPED_TEST(BlendShapesTest, Fitting) {
   SkeletonSolverFunctionT<T> solverFunction(
       &characterBlend.skeleton, &castedCharacterBlendParameterTransform);
 
-  VertexErrorFunctionT<T> errorFunction(characterBlend);
+  auto errorFunction = std::make_shared<VertexErrorFunctionT<T>>(characterBlend);
   for (size_t iVert = 0; iVert < targetMesh.vertices.size(); ++iVert) {
-    errorFunction.addConstraint(iVert, 1.0, targetMesh.vertices[iVert], targetMesh.normals[iVert]);
+    errorFunction->addConstraint(iVert, 1.0, targetMesh.vertices[iVert], targetMesh.normals[iVert]);
   }
-  solverFunction.addErrorFunction(&errorFunction);
+  solverFunction.addErrorFunction(errorFunction);
 
   // create solver
   GaussNewtonSolverQROptions options;

--- a/momentum/test/character_solver/inverse_kinematics_test.cpp
+++ b/momentum/test/character_solver/inverse_kinematics_test.cpp
@@ -47,10 +47,10 @@ void testSimpleTargets(const SolverOptionsT& options) {
   SkeletonSolverFunctionT<T> solverFunction(&skeleton, &castedCharacterParameterTransform);
 
   // create marker solvable
-  PositionErrorFunctionT<T> errorFunction(skeleton, transform);
+  auto errorFunction = std::make_shared<PositionErrorFunctionT<T>>(skeleton, transform);
 
   // add to solvable
-  solverFunction.addErrorFunction(&errorFunction);
+  solverFunction.addErrorFunction(errorFunction);
 
   // create solver
   GaussNewtonSolverT<T> solver(options, &solverFunction);
@@ -70,7 +70,7 @@ void testSimpleTargets(const SolverOptionsT& options) {
 
   {
     SCOPED_TRACE("Checking optimizing rest pose");
-    errorFunction.setConstraints(constraints);
+    errorFunction->setConstraints(constraints);
     const T error = solver.solve(optimizedParameters);
     state.set(castedCharacterParameterTransform.apply(optimizedParameters), skeleton);
     EXPECT_LE(error, Eps<T>(1e-7f, 1e-15));
@@ -84,7 +84,7 @@ void testSimpleTargets(const SolverOptionsT& options) {
     SCOPED_TRACE("Checking optimizing target pose");
     for (size_t i = 0; i < 10; i++) {
       constraints[0].target = Vector3<T>::Random() * 3.0;
-      errorFunction.setConstraints(constraints);
+      errorFunction->setConstraints(constraints);
       const T error = solver.solve(optimizedParameters);
       state.set(castedCharacterParameterTransform.apply(optimizedParameters), skeleton);
       EXPECT_LE(error, Eps<T>(5e-7f, 1e-8));

--- a/momentum/test/character_solver/solver_test.cpp
+++ b/momentum/test/character_solver/solver_test.cpp
@@ -79,25 +79,27 @@ TYPED_TEST(GaussNewtonQRTest, CompareGaussNewton) {
 
     targetParams.push_back(randomParams_cur.v);
 
-    PositionErrorFunctionT<T> positionErrorFunction(skeleton, parameterTransform);
-    OrientationErrorFunctionT<T> orientErrorFunction(skeleton, parameterTransform);
+    auto positionErrorFunction =
+        std::make_shared<PositionErrorFunctionT<T>>(skeleton, parameterTransform);
+    auto orientErrorFunction =
+        std::make_shared<OrientationErrorFunctionT<T>>(skeleton, parameterTransform);
     SkeletonStateT<T> skelState_cur(
         castedCharacterParameterTransform.apply(randomParams_cur), character.skeleton);
     for (size_t iJoint = 0; iJoint < skelState_cur.jointState.size(); ++iJoint) {
-      positionErrorFunction.addConstraint(PositionDataT<T>(
+      positionErrorFunction->addConstraint(PositionDataT<T>(
           Eigen::Vector3<T>::Zero(),
           skelState_cur.jointState[iJoint].translation().template cast<T>(),
           iJoint,
           1.0));
-      orientErrorFunction.addConstraint(OrientationDataT<T>(
+      orientErrorFunction->addConstraint(OrientationDataT<T>(
           Eigen::Quaternion<T>::Identity(),
           skelState_cur.jointState[iJoint].rotation().template cast<T>(),
           iJoint,
           1.0));
     }
 
-    solverFunction.addErrorFunction(&positionErrorFunction);
-    solverFunction.addErrorFunction(&orientErrorFunction);
+    solverFunction.addErrorFunction(positionErrorFunction);
+    solverFunction.addErrorFunction(orientErrorFunction);
 
     SubsetGaussNewtonSolverT<T> solver_sub(subsetGaussNewtonSolverOptions, &solverFunction);
     const T err_sub = test::checkAndTimeSolver<T>(solverFunction, solver_sub, parametersInit);
@@ -140,11 +142,12 @@ TYPED_TEST(TrustRegionTest, PerfectQuadratic) {
     ModelParametersT<T> randomParams_cur =
         VectorX<T>::Random(parameterTransform.numAllModelParameters());
 
-    ModelParametersErrorFunctionT<T> mpErrorFunction(skeleton, parameterTransform);
+    auto mpErrorFunction =
+        std::make_shared<ModelParametersErrorFunctionT<T>>(skeleton, parameterTransform);
     Eigen::VectorX<T> weights =
         VectorX<T>::Random(parameterTransform.numAllModelParameters()).array().abs();
-    mpErrorFunction.setTargetParameters(randomParams_cur, weights);
-    solverFunction.addErrorFunction(&mpErrorFunction);
+    mpErrorFunction->setTargetParameters(randomParams_cur, weights);
+    solverFunction.addErrorFunction(mpErrorFunction);
 
     TrustRegionQRT<T> solver_tr(test::defaultSolverOptions(), &solverFunction);
     const T err_tr = test::checkAndTimeSolver<T>(solverFunction, solver_tr, parametersInit);
@@ -182,25 +185,27 @@ TYPED_TEST(TrustRegionTest, SanityCheck) {
 
     targetParams.push_back(randomParams_cur.v);
 
-    PositionErrorFunctionT<T> positionErrorFunction(skeleton, character.parameterTransform);
-    OrientationErrorFunctionT<T> orientErrorFunction(skeleton, character.parameterTransform);
+    auto positionErrorFunction =
+        std::make_shared<PositionErrorFunctionT<T>>(skeleton, character.parameterTransform);
+    auto orientErrorFunction =
+        std::make_shared<OrientationErrorFunctionT<T>>(skeleton, character.parameterTransform);
     SkeletonStateT<T> skelState_cur(
         castedCharacterParameterTransform.apply(randomParams_cur), character.skeleton);
     for (size_t iJoint = 0; iJoint < skelState_cur.jointState.size(); ++iJoint) {
-      positionErrorFunction.addConstraint(PositionDataT<T>(
+      positionErrorFunction->addConstraint(PositionDataT<T>(
           Eigen::Vector3<T>::Zero(),
           skelState_cur.jointState[iJoint].translation().template cast<T>(),
           iJoint,
           1.0));
-      orientErrorFunction.addConstraint(OrientationDataT<T>(
+      orientErrorFunction->addConstraint(OrientationDataT<T>(
           Eigen::Quaternion<T>::Identity(),
           skelState_cur.jointState[iJoint].rotation().template cast<T>(),
           iJoint,
           1.0));
     }
 
-    solverFunction.addErrorFunction(&positionErrorFunction);
-    solverFunction.addErrorFunction(&orientErrorFunction);
+    solverFunction.addErrorFunction(positionErrorFunction);
+    solverFunction.addErrorFunction(orientErrorFunction);
 
     TrustRegionQRT<T> solver_tr(test::defaultSolverOptions(), &solverFunction);
     const T err_tr = test::checkAndTimeSolver<T>(solverFunction, solver_tr, parametersInit);

--- a/momentum/test/diff_ik/test_differentiable_ik.cpp
+++ b/momentum/test/diff_ik/test_differentiable_ik.cpp
@@ -96,7 +96,7 @@ TEST(DifferentiableIK, Basic) {
     }
     positionError->setWeight(j + 1);
     errorFunctions.push_back(positionError);
-    solverFunction.addErrorFunction(positionError.get());
+    solverFunction.addErrorFunction(positionError);
   }
 
   {
@@ -111,7 +111,7 @@ TEST(DifferentiableIK, Basic) {
     }
     rotationError->setWeight(3);
     errorFunctions.push_back(rotationError);
-    solverFunction.addErrorFunction(rotationError.get());
+    solverFunction.addErrorFunction(rotationError);
   }
 
   {
@@ -119,7 +119,7 @@ TEST(DifferentiableIK, Basic) {
         skeleton, character.parameterTransform, parameterLimits);
     limitError->setWeight(0.1f);
     errorFunctions.push_back(limitError);
-    solverFunction.addErrorFunction(limitError.get());
+    solverFunction.addErrorFunction(limitError);
   }
 
   GaussNewtonSolverQRT<T> solver(solverOptions, &solverFunction);

--- a/pymomentum/cpp_test/tensor_ik_test.cpp
+++ b/pymomentum/cpp_test/tensor_ik_test.cpp
@@ -115,12 +115,12 @@ void addPositionConstraints(
 
 template <typename T>
 struct IKProblem {
-  std::unique_ptr<momentum::FullyDifferentiablePositionErrorFunctionT<T>>
+  std::shared_ptr<momentum::FullyDifferentiablePositionErrorFunctionT<T>>
       markerError;
-  std::unique_ptr<momentum::LimitErrorFunction> limitError;
-  std::unique_ptr<momentum::FullyDifferentiableOrientationErrorFunctionT<T>>
+  std::shared_ptr<momentum::LimitErrorFunction> limitError;
+  std::shared_ptr<momentum::FullyDifferentiableOrientationErrorFunctionT<T>>
       orientationError;
-  std::unique_ptr<momentum::SkeletonSolverFunction> solverFunction;
+  std::shared_ptr<momentum::SkeletonSolverFunction> solverFunction;
 
   Eigen::VectorX<T> modelParameters_init;
   Eigen::VectorX<T> modelParameters_final;
@@ -181,7 +181,7 @@ TEST(TensorIK, TensorIK) {
         std::make_unique<momentum::SkeletonSolverFunction>(
             &character.skeleton, &character.parameterTransform);
 
-    ikProblems[iBatch].markerError = std::make_unique<
+    ikProblems[iBatch].markerError = std::make_shared<
         momentum::FullyDifferentiablePositionErrorFunctionT<T>>(
         character.skeleton, character.parameterTransform);
     ikProblems[iBatch].markerError->setWeight(2.0f + unif(rng));
@@ -194,21 +194,21 @@ TEST(TensorIK, TensorIK) {
     // pymomentum::printConstraintList(ikProblems[iBatch].markerError->getConstraints(),
     // std::cout);
     ikProblems[iBatch].solverFunction->addErrorFunction(
-        ikProblems[iBatch].markerError.get());
+        ikProblems[iBatch].markerError);
 
     ikProblems[iBatch].limitError =
-        std::make_unique<momentum::LimitErrorFunction>(
+        std::make_shared<momentum::LimitErrorFunction>(
             character.skeleton,
             character.parameterTransform,
             character.parameterLimits);
     ikProblems[iBatch].solverFunction->addErrorFunction(
-        ikProblems[iBatch].limitError.get());
+        ikProblems[iBatch].limitError);
 
-    ikProblems[iBatch].orientationError = std::make_unique<
+    ikProblems[iBatch].orientationError = std::make_shared<
         momentum::FullyDifferentiableOrientationErrorFunctionT<T>>(
         character.skeleton, character.parameterTransform);
     ikProblems[iBatch].solverFunction->addErrorFunction(
-        ikProblems[iBatch].orientationError.get());
+        ikProblems[iBatch].orientationError);
 
     momentum::GaussNewtonSolver solver(
         solverOptions, ikProblems[iBatch].solverFunction.get());


### PR DESCRIPTION
Summary: For better lifecycle handling of error functions passed to SkeletonSolverFunction (e.g., the error fixed in D64085929)

Differential Revision: D64086809


