### PR TITLE
Fix mem alignment in SIMD error functions

### DIFF
--- a/momentum/character_solver/simd_position_error_function.cpp
+++ b/momentum/character_solver/simd_position_error_function.cpp
@@ -160,10 +160,6 @@ double SimdPositionErrorFunction::getGradient(
   // Storage for joint errors
   std::vector<double> jointErrors(constraints_->numJoints);
 
-  // Need to make sure we're actually at a kSimdAlignment byte data offset at the first offset for
-  // SIMD access
-  checkAlignment<kSimdAlignment>(gradient);
-
   // Loop over all joints, as these are our base units
   auto dispensoOptions = dispenso::ParForOptions();
   dispensoOptions.maxThreads = maxThreads_;
@@ -311,10 +307,6 @@ double SimdPositionErrorFunction::getJacobian(
 
   // Storage for joint errors
   std::vector<double> jointErrors(constraints_->numJoints);
-
-  // Need to make sure we're actually at a kSimdAlignment byte data offset at the first offset for
-  // SIMD access
-  checkAlignment<kSimdAlignment>(jacobian);
 
   // Loop over all joints, as these are our base units
   auto dispensoOptions = dispenso::ParForOptions();
@@ -802,7 +794,8 @@ double SimdPositionErrorFunctionAVX::getJacobian(
   std::vector<double> ets_error;
 
   // need to make sure we're actually at a 32 byte data offset at the first offset for AVX access
-  checkAlignment<kAvxAlignment>(jacobian);
+  const size_t addressOffset = computeOffset<kAvxAlignment>(jacobian);
+  checkAlignment<kAvxAlignment>(jacobian, addressOffset);
 
   // loop over all joints, as these are our base units
   auto dispensoOptions = dispenso::ParForOptions();
@@ -814,7 +807,7 @@ double SimdPositionErrorFunctionAVX::getJacobian(
       constraints_->numJoints,
       [&](double& error_local, const size_t jointId) {
         // get initial offset
-        const auto offset = jacobianOffset_[jointId];
+        const auto offset = jacobianOffset_[jointId] + addressOffset;
 
         // pre-load some joint specific values
         const auto& transformation = state.jointState[jointId].transformation;

--- a/momentum/simd/simd.h
+++ b/momentum/simd/simd.h
@@ -49,11 +49,26 @@ using Vector3fP = Vector3P<float>;
 using Vector2dP = Vector2P<double>;
 using Vector3dP = Vector3P<double>;
 
+/// Computes the offset required for the matrix data to meet the alignment requirement.
+template <size_t Alignment>
+[[nodiscard]] size_t computeOffset(const Eigen::Ref<Eigen::MatrixXf>& mat) {
+  constexpr size_t sizeOfScalar = sizeof(typename Eigen::MatrixXf::Scalar);
+  const size_t addressOffset =
+      Alignment / sizeOfScalar - (((size_t)mat.data() % Alignment) / sizeOfScalar);
+
+  // If the current alignment already meets the requirement, no offset is needed.
+  if (addressOffset == Alignment / sizeOfScalar) {
+    return 0;
+  }
+
+  return addressOffset;
+}
+
 /// Checks if the data of the matrix is aligned correctly.
 template <size_t Alignment>
-void checkAlignment(const Eigen::Ref<Eigen::MatrixXf>& mat) {
+void checkAlignment(const Eigen::Ref<Eigen::MatrixXf>& mat, size_t offset = 0) {
   MT_THROW_IF(
-      (uintptr_t(mat.data())) % Alignment != 0,
+      (uintptr_t(mat.data() + offset)) % Alignment != 0,
       "Matrix ({}x{}, ptr: {}) is not aligned ({}) correctly.",
       mat.rows(),
       mat.cols(),


### PR DESCRIPTION
Summary:
Memory alignment checks were added by D63658278 for both AVX and DrJit implementations, but introduced an error in the AVX implementation where Jacobian pointers were not offset to aligned memory address.

Diff fixes issue by using new utility function that computes offset and checks alignment with offset, and also removes alignment check from DrJit implementation since current implementation does not require memory alignment (to be addressed in upper Diff stack).

Differential Revision: D64132292


