### PR TITLE
Avoid using deprecated gsl headers in 4.0

### DIFF
--- a/momentum/character_solver/gauss_newton_solver_qr.cpp
+++ b/momentum/character_solver/gauss_newton_solver_qr.cpp
@@ -10,7 +10,7 @@
 #include "momentum/character_solver/skeleton_error_function.h"
 #include "momentum/common/profile.h"
 
-#include <gsl/gsl_util>
+#include <gsl/util>
 
 namespace momentum {
 


### PR DESCRIPTION
Summary:
All the `gsl/gsl_` headers are deprecated in 4.0 (and removed in 4.1):

https://github.com/microsoft/GSL/releases/tag/v4.0.0

Differential Revision:
D64650257

Privacy Context Container: L1129542


