### PR TITLE
Support GSL 4.1+

### DIFF
--- a/momentum/character_solver/gauss_newton_solver_qr.cpp
+++ b/momentum/character_solver/gauss_newton_solver_qr.cpp
@@ -10,7 +10,11 @@
 #include "momentum/character_solver/skeleton_error_function.h"
 #include "momentum/common/profile.h"
 
+#ifdef MOMENTUM_WITH_GSL3
 #include <gsl/gsl_util>
+#else
+#include <gsl/util>
+#endif
 
 namespace momentum {
 


### PR DESCRIPTION
Summary: The `<gsl/gsl_*>` headers are [deprecated](https://github.com/microsoft/GSL/releases/tag/v4.0.0) in version 4.0 and removed in version 4.1. This diff aims to enable momentum builds with GSL 4.1+, thereby resolving the build failure:

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1058841&view=logs&j=d6b58996-039f-5e48-56bf-c3a016e5cd7f&t=dd6a23d9-2356-5264-64bf-579875a5d8d6&l=1654

Differential Revision: D64651488


