### PR TITLE
Improve build with FBX on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,36 +318,33 @@ mt_library(
 if(MOMENTUM_BUILD_IO_FBX)
   if(DEFINED ENV{FBXSDK_PATH})
     set(fbxsdk_path $ENV{FBXSDK_PATH})
-
-    if(NOT EXISTS "${fbxsdk_path}")
-      message(FATAL_ERROR "FBXSDK_PATH does not exist: ${fbxsdk_path}")
-    endif()
-
-    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-      set(io_fbx_sources_var io_fbx_sources_windows)
-      set(fbxsdk_libs
-        "${fbxsdk_path}/lib/vs2017/x64/release/libfbxsdk-md.lib"
-        "${fbxsdk_path}/lib/vs2017/x64/release/libxml2-md.lib"
-        "${fbxsdk_path}/lib/vs2017/x64/release/zlib-md.lib"
-      )
-    else()
-      message(FATAL_ERROR "Unsupported platform")
-    endif()
-
-    mt_library(
-      NAME fbxsdk
-      PUBLIC_INCLUDE_DIRECTORIES
-        "${fbxsdk_path}/include"
-      PUBLIC_LINK_LIBRARIES
-        ${fbxsdk_libs}
-    )
-
-    set(io_fbx_private_link_libraries fbxsdk)
   else()
-    message(WARNING "MOMENTUM_BUILD_IO_FBX is enabled, but the FBXSDK_PATH environment variable is not defined. The build will proceed without the FBX SDK. Please download the required FBX SDK 2019.2 from the Autodesk Developer Network: https://aps.autodesk.com/developer/overview/fbx-sdk. After installation, set FBXSDK_PATH to the installation directory, for example, 'C:\\Program Files\\Autodesk\\FBX\\FBX SDK\\2019.2'.")
-    set(io_fbx_sources_var io_fbx_sources_unsupported)
-    set(io_fbx_private_link_libraries )
+    set(fbxsdk_path "C:/Program Files/Autodesk/FBX/FBX SDK/2019.2")
   endif()
+
+  if(NOT EXISTS "${fbxsdk_path}")
+    message(FATAL_ERROR "The FBX SDK path '${fbxsdk_path}' does not exist. Please download the required FBX SDK 2019.2 from https://aps.autodesk.com/developer/overview/fbx-sdk or https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_vs2017_win.exe. After installation, set FBXSDK_PATH to the installation directory if it's not installed to the default path.")
+  endif()
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(io_fbx_sources_var io_fbx_sources_windows)
+    set(fbxsdk_libs
+      "${fbxsdk_path}/lib/vs2017/x64/release/libfbxsdk-md.lib"
+      "${fbxsdk_path}/lib/vs2017/x64/release/libxml2-md.lib"
+      "${fbxsdk_path}/lib/vs2017/x64/release/zlib-md.lib"
+    )
+  else()
+    message(FATAL_ERROR "Unsupported platform")
+  endif()
+
+  mt_library(
+    NAME fbxsdk
+    PUBLIC_INCLUDE_DIRECTORIES
+      "${fbxsdk_path}/include"
+    PUBLIC_LINK_LIBRARIES
+      ${fbxsdk_libs}
+  )
+  set(io_fbx_private_link_libraries fbxsdk)
 else()
   set(io_fbx_sources_var io_fbx_sources_unsupported)
   set(io_fbx_private_link_libraries )

--- a/README.md
+++ b/README.md
@@ -129,7 +129,29 @@ If you need to start over for any reason:
 pixi run clean
 ```
 
-Momentum uses the `build/` directory for CMake builds, `.pixi/` for the Pixi virtual environment, and `.deps/` for building dependencies. You can clean up everything by either manually removing these directories or by running the command above.
+Momentum uses the `build/` directory for CMake builds, and `.pixi/` for the Pixi virtual environment. You can clean up everything by either manually removing these directories or by running the command above.
+
+#### FBX support (Windows only)
+
+To load and save Autodesk's FBX file format, you need to install the FBX SDK 2019.2 from Autodesk's [website](https://aps.autodesk.com/developer/overview/fbx-sdk) or [this direct link](https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_vs2017_win.exe) first. After installing the SDK, you can build with `MOMENTUM_BUILD_IO_FBX=ON`:
+
+```
+# Powershell
+$env:MOMENTUM_BUILD_IO_FBX = "ON"; pixi run <target>
+
+# cmd
+set MOMENTUM_BUILD_IO_FBX=ON && pixi run <target>
+```
+
+For example, file conversion can be run as follows:
+
+```
+# Powershell
+$env:MOMENTUM_BUILD_IO_FBX = "ON"; pixi run convert_model -d <input.glb> -o <out.fbx>
+
+# cmd
+set MOMENTUM_BUILD_IO_FBX=ON && pixi run convert_model -d <input.glb> -o <out.fbx>
+```
 
 ## 📖 Documentation
 

--- a/momentum/website/docs/02_user_guide/01_getting_started.md
+++ b/momentum/website/docs/02_user_guide/01_getting_started.md
@@ -108,4 +108,26 @@ If you need to start over for any reason:
 pixi run clean
 ```
 
-Momentum uses the `build/` directory for CMake builds, `.pixi/` for the Pixi virtual environment, and `.deps/` for building dependencies. You can clean up everything by either manually removing these directories or by running the command above.
+Momentum uses the `build/` directory for CMake builds, and `.pixi/` for the Pixi virtual environment. You can clean up everything by either manually removing these directories or by running the command above.
+
+### FBX support (Windows only)
+
+To load and save Autodesk's FBX file format, you need to install the FBX SDK 2019.2 from Autodesk's [website](https://aps.autodesk.com/developer/overview/fbx-sdk) or [this direct link](https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_vs2017_win.exe) first. After installing the SDK, you can build with `MOMENTUM_BUILD_IO_FBX=ON`:
+
+```
+# Powershell
+$env:MOMENTUM_BUILD_IO_FBX = "ON"; pixi run <target>
+
+# cmd
+set MOMENTUM_BUILD_IO_FBX=ON && pixi run <target>
+```
+
+For example, file conversion can be run as follows:
+
+```
+# Powershell
+$env:MOMENTUM_BUILD_IO_FBX = "ON"; pixi run convert_model -d <input.glb> -o <out.fbx>
+
+# cmd
+set MOMENTUM_BUILD_IO_FBX=ON && pixi run convert_model -d <input.glb> -o <out.fbx>
+```

--- a/pixi.toml
+++ b/pixi.toml
@@ -43,13 +43,14 @@ spdlog = ">=1.12.0"
 
 [tasks]
 clean = { cmd = "rm -rf build && rm -rf .pixi && rm pixi.lock" }
-configure = { cmd = """
+config = { cmd = """
     cmake \
         -S . \
         -B build \
         -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DMOMENTUM_BUILD_IO_FBX=OFF \
         -DMOMENTUM_BUILD_TESTING=ON \
         -DMOMENTUM_BUILD_EXAMPLES=ON \
         -DMOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
@@ -58,9 +59,7 @@ configure = { cmd = """
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
     """, env = { MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
-build = { cmd = "cmake --build build -j --target all", depends_on = [
-    "configure",
-] }
+build = { cmd = "cmake --build build -j --target all", depends_on = ["config"] }
 test = { cmd = "ctest --test-dir build --output-on-failure", depends_on = [
     "build",
 ] }
@@ -112,9 +111,7 @@ pytorch = ">=2.4.0"
 
 [target.osx.tasks]
 lint = { cmd = "clang-format-18 -i axel/**/*.h axel/**/*.cpp momentum/**/*.h momentum/**/*.cpp pymomentum/**/*.h pymomentum/**/*.cpp" }
-build = { cmd = "cmake --build build -j --target all", depends_on = [
-    "configure",
-] }
+build = { cmd = "cmake --build build -j --target all", depends_on = ["config"] }
 build_pymomentum = { cmd = "pip install -e ." }
 # TODO: Add test_pymomentum once segfault on import is fixed
 
@@ -130,9 +127,7 @@ pytorch = ">=2.4.0"
 
 [target.osx-arm64.tasks]
 lint = { cmd = "clang-format-18 -i axel/**/*.h axel/**/*.cpp momentum/**/*.h momentum/**/*.cpp pymomentum/**/*.h pymomentum/**/*.cpp" }
-build = { cmd = "cmake --build build -j --target all", depends_on = [
-    "configure",
-] }
+build = { cmd = "cmake --build build -j --target all", depends_on = ["config"] }
 build_pymomentum = { cmd = "pip install -e ." }
 # TODO: Add test_pymomentum once segfault on import is fixed
 
@@ -143,7 +138,7 @@ build_pymomentum = { cmd = "pip install -e ." }
 [target.win-64.dependencies]
 
 [target.win-64.tasks]
-configure = { cmd = """
+config = { cmd = """
     cmake \
         -S . \
         -B build \
@@ -151,19 +146,17 @@ configure = { cmd = """
         -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
         -DBUILD_SHARED_LIBS=OFF \
         -DMOMENTUM_BUILD_EXAMPLES=ON \
-        -DMOMENTUM_BUILD_IO_FBX=ON \
+        -DMOMENTUM_BUILD_IO_FBX=$MOMENTUM_BUILD_IO_FBX \
         -DMOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
         -DMOMENTUM_BUILD_TESTING=ON \
         -DMOMENTUM_ENABLE_SIMD=%MOMENTUM_ENABLE_SIMD% \
         -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
-    """, env = { MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "OFF" } }
-open_vs = { cmd = "cmd /c start build\\momentum.sln", depends_on = [
-    "configure",
-] }
+    """, env = { MOMENTUM_BUILD_IO_FBX = "OFF", MOMENTUM_BUILD_PYMOMENTUM = "OFF", MOMENTUM_ENABLE_SIMD = "ON" } }
+open_vs = { cmd = "cmd /c start build\\momentum.sln", depends_on = ["config"] }
 build = { cmd = "cmake --build build -j --config Release", depends_on = [
-    "configure",
+    "config",
 ] }
 test = { cmd = "ctest --test-dir build --output-on-failure --build-config Release", depends_on = [
     "build",


### PR DESCRIPTION
## Summary

- Shorten Pixi task name from `configure` to `config` for brevity
- Treat failure to find FBX SDK as a configuration error when `MOMENTUM_IO_BUILD=ON`, and update the error message to be more precise
- Use the default FBX SDK installation path when the `FBXSDK_PATH` environment variable is not set, otherwise use the specified path
- Improve the README and website documentation for FBX SDK support

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

Locally tested that building with and without FBX SDK installed worked as expected
