### PR TITLE
Fix pymomentum link error on macOS

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -44,16 +44,12 @@ jobs:
           pixi run cmake --build momentum/examples/hello_world/build
 
   pymomentum:
-    name: pymomentum-${{ matrix.platform }}
+    name: pymomentum-${{ matrix.os == 'macos-latest-large' && 'mac-x86_64' || 'mac-arm64' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: macos-latest
-            platform: mac-arm
-          - os: macos-latest-large
-            platform: mac-intel
+        os: [macos-latest, macos-latest-large]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,7 +57,6 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
           cache: true
-      - name: Build PyMomentum
-        # TODO: Change to test_pymomentum once segfault on import is fixed
+      - name: Build and test PyMomentum
         run: |
-          pixi run build_pymomentum
+          pixi run test_pymomentum

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -100,10 +100,6 @@ jobs:
           environments: ${{ matrix.pixi_env }}
           cache: true
 
-      - name: Check pixi environments
-        run: |
-          pixi info
-
       - name: Build PyMomentum
         run: |
           pixi run -e ${{ matrix.pixi_env }} test_pymomentum

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # python
 *.egg-info/
 *.cpython-*.so
+*.pyc
 
 # build artifacts
 build/

--- a/README.md
+++ b/README.md
@@ -50,16 +50,8 @@ pixi add momentum
 
 ```
 conda install -c conda-forge momentum-cpp
-conda install -c conda-forge pymomentum # Linux only
+conda install -c conda-forge pymomentum # Windows is not supported yet
 conda install -c conda-forge momentum
-```
-
-#### Micromamba
-
-```
-micromamba install -c conda-forge momentum-cpp
-micromamba install -c conda-forge pymomentum # Linux only
-micromamba install -c conda-forge momentum
 ```
 
 ### Building Momentum from Source

--- a/momentum/website/docs/02_user_guide/01_getting_started.md
+++ b/momentum/website/docs/02_user_guide/01_getting_started.md
@@ -29,16 +29,8 @@ pixi add momentum
 
 ```
 conda install -c conda-forge momentum-cpp
-conda install -c conda-forge pymomentum # Linux only
+conda install -c conda-forge pymomentum # Windows is not supported yet
 conda install -c conda-forge momentum
-```
-
-### Micromamba
-
-```
-micromamba install -c conda-forge momentum-cpp
-micromamba install -c conda-forge pymomentum # Linux only
-micromamba install -c conda-forge momentum
 ```
 
 ## Building Momentum from Source

--- a/pixi.toml
+++ b/pixi.toml
@@ -111,7 +111,17 @@ pytorch = ">=2.4.0"
 [target.osx.tasks]
 build = { cmd = "cmake --build build -j --target all", depends_on = ["config"] }
 build_pymomentum = { cmd = "pip install -e ." }
-# TODO: Add test_pymomentum once segfault on import is fixed
+test_pymomentum = { cmd = """
+    pytest \
+        pymomentum/test/test_closest_points.py \
+        pymomentum/test/test_fbx.py \
+        pymomentum/test/test_parameter_transform.py \
+        pymomentum/test/test_quaternion.py \
+        pymomentum/test/test_skel_state.py \
+        pymomentum/test/test_skeleton.py
+    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends_on = [
+    "build_pymomentum",
+] }
 
 #============
 # osx-arm64
@@ -125,7 +135,17 @@ pytorch = ">=2.4.0"
 [target.osx-arm64.tasks]
 build = { cmd = "cmake --build build -j --target all", depends_on = ["config"] }
 build_pymomentum = { cmd = "pip install -e ." }
-# TODO: Add test_pymomentum once segfault on import is fixed
+test_pymomentum = { cmd = """
+    pytest \
+        pymomentum/test/test_closest_points.py \
+        pymomentum/test/test_fbx.py \
+        pymomentum/test/test_parameter_transform.py \
+        pymomentum/test/test_quaternion.py \
+        pymomentum/test/test_skel_state.py \
+        pymomentum/test/test_skeleton.py
+    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends_on = [
+    "build_pymomentum",
+] }
 
 #=========
 # win-64

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -72,7 +72,7 @@ mt_library(
     momentum
     nlohmann_json::nlohmann_json
     pybind11::pybind11
-    Python3::Python
+    Python3::Module
   EXCLUDE_FROM_INSTALL
 )
 


### PR DESCRIPTION
## Summary

Fix pymomentum link error by replacing `Python::Python` to `Python::Module`

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

```
pixi r test
pixi r test_pymomentum
```
