### PR TITLE
Build with FBX SDK by default on Ubuntu

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -14,30 +14,29 @@ on:
 
 jobs:
   momentum:
-    name: momentum-simd:${{ matrix.simd }}-ubuntu
+    name: momentum${{ matrix.simd == 'ON' && '-simd' || '' }}-ubuntu
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - simd: "ON"
-            pymomentum: "ON"
-          - simd: "OFF"
-            pymomentum: "OFF"
+        simd: ["ON", "OFF"]
     env:
       MOMENTUM_ENABLE_SIMD: ${{ matrix.simd }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
           cache: true
+
       - name: Build and test Momentum
         run: |
           MOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
             MOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
             pixi run test
+
       - name: Install Momentum and Build hello_world
         run: |
           MOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,35 +316,9 @@ mt_library(
 )
 
 if(MOMENTUM_BUILD_IO_FBX)
-  if(DEFINED ENV{FBXSDK_PATH})
-    set(fbxsdk_path $ENV{FBXSDK_PATH})
-  else()
-    set(fbxsdk_path "C:/Program Files/Autodesk/FBX/FBX SDK/2020.3.7")
-  endif()
-
-  if(NOT EXISTS "${fbxsdk_path}")
-    message(FATAL_ERROR "The FBX SDK path '${fbxsdk_path}' does not exist. Please download the required FBX SDK 2020.3 from https://aps.autodesk.com/developer/overview/fbx-sdk or https://damassets.autodesk.net/content/dam/autodesk/www/files/fbx202037_fbxsdk_vs2019_win.exe. After installation, set FBXSDK_PATH to the installation directory if it's not installed to the default path.")
-  endif()
-
-  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    set(io_fbx_sources_var io_fbx_sources)
-    set(fbxsdk_libs
-      "${fbxsdk_path}/lib/x64/release/libfbxsdk-md.lib"
-      "${fbxsdk_path}/lib/x64/release/libxml2-md.lib"
-      "${fbxsdk_path}/lib/x64/release/zlib-md.lib"
-    )
-  else()
-    message(FATAL_ERROR "Unsupported platform")
-  endif()
-
-  mt_library(
-    NAME fbxsdk
-    PUBLIC_INCLUDE_DIRECTORIES
-      "${fbxsdk_path}/include"
-    PUBLIC_LINK_LIBRARIES
-      ${fbxsdk_libs}
-  )
-  set(io_fbx_private_link_libraries fbxsdk)
+  set(io_fbx_sources_var io_fbx_sources)
+  find_package(FbxSdk MODULE REQUIRED)
+  set(io_fbx_private_link_libraries fbxsdk::fbxsdk)
 else()
   set(io_fbx_sources_var io_fbx_sources_unsupported)
   set(io_fbx_private_link_libraries )

--- a/README.md
+++ b/README.md
@@ -125,9 +125,21 @@ pixi run clean
 
 Momentum uses the `build/` directory for CMake builds, and `.pixi/` for the Pixi virtual environment. You can clean up everything by either manually removing these directories or by running the command above.
 
-#### FBX support (Windows only)
+#### FBX Support
 
-Momentum uses OpenFBX to load Autodesk's FBX file format, which is built by default. To save files in FBX format, you need to install the FBX SDK 2020.3. You can download it from Autodesk's [website](https://aps.autodesk.com/developer/overview/fbx-sdk) or use [this direct link](https://damassets.autodesk.net/content/dam/autodesk/www/files/fbx202037_fbxsdk_vs2019_win.exe). After installing the SDK, build Momentum from source with `MOMENTUM_BUILD_IO_FBX=ON` option as:
+Momentum uses OpenFBX to load Autodesk's FBX file format, which is enabled by default. To save files in FBX format, you must install the FBX SDK 2020.3.
+
+##### Linux
+
+The FBX SDK will be automatically installed when you run `pixi run config`, so no additional steps are required.
+
+##### macOS
+
+Currently, building with the FBX SDK on macOS is not supported.
+
+##### Windows
+
+You can download it from Autodesk's [website](https://aps.autodesk.com/developer/overview/fbx-sdk) or use [this direct link](https://damassets.autodesk.net/content/dam/autodesk/www/files/fbx202037_fbxsdk_vs2019_win.exe). After installing the SDK, build Momentum from source with `MOMENTUM_BUILD_IO_FBX=ON` option as:
 
 ```
 # Powershell

--- a/cmake/FindFbxSdk.cmake
+++ b/cmake/FindFbxSdk.cmake
@@ -1,0 +1,103 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set(_fbxsdk_version "2020.3.7")
+
+message(DEBUG "Looking for FBX SDK version: ${_fbxsdk_version}")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(_fbxsdk_approot "/Applications/Autodesk/FBX SDK")
+  set(_fbxsdk_libdir_release "lib/clang/release")
+  set(_fbxsdk_libdir_debug "lib/clang/debug")
+  list(APPEND _fbxsdk_libnames_release "libalembic.a" "libfbxsdk.a")
+  list(APPEND _fbxsdk_libnames_debug "libalembic.a" "libfbxsdk.a")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  set(_fbxsdk_approot "C:/Program Files/Autodesk/FBX/FBX SDK")
+  set(_fbxsdk_libdir_release "lib/x64/release")
+  set(_fbxsdk_libdir_debug "lib/x64/debug")
+  list(APPEND _fbxsdk_libnames_release "libfbxsdk-md.lib" "alembic-md.lib" "libxml2-md.lib" "zlib-md.lib")
+  list(APPEND _fbxsdk_libnames_debug "libfbxsdk-md.lib" "alembic-md.lib" "libxml2-md.lib" "zlib-md.lib")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(_fbxsdk_approot "/usr/fbxsdk")
+  set(_fbxsdk_libdir_release "lib/release")
+  set(_fbxsdk_libdir_debug "lib/debug")
+  list(APPEND _fbxsdk_libnames_release "libalembic.a" "libfbxsdk.a")
+  list(APPEND _fbxsdk_libnames_debug "libalembic.a" "libfbxsdk.a")
+else()
+  message(FATAL_ERROR "Unsupported OS: ${CMAKE_SYSTEM_NAME}")
+endif()
+
+# overwrite if FBXSDK_PATH is defined
+if(DEFINED ENV{FBXSDK_PATH})
+  set(_fbxsdk_approot "$ENV{FBXSDK_PATH}")
+endif()
+
+# should point the the FBX SDK installation dir
+set(_fbxsdk_root "${_fbxsdk_approot}/${_fbxsdk_version}")
+message(DEBUG "_fbxsdk_root: ${_fbxsdk_root}")
+
+# find header dir
+find_path(
+  FBXSDK_INCLUDE_DIR "fbxsdk.h"
+  PATHS ${_fbxsdk_root}
+  PATH_SUFFIXES "include"
+)
+message(DEBUG "FBXSDK_INCLUDE_DIR: ${FBXSDK_INCLUDE_DIR}")
+
+# find release libs
+foreach(libname ${_fbxsdk_libnames_release})
+  find_library(
+    lib_${libname} ${libname}
+    PATHS ${_fbxsdk_root}
+    PATH_SUFFIXES ${_fbxsdk_libdir_release}
+  )
+  list(APPEND FBXSDK_LIBRARIES ${lib_${libname}})
+endforeach()
+message(DEBUG "FBXSDK_LIBRARIES: ${FBXSDK_LIBRARIES}")
+
+# find debug libs
+foreach(libname ${_fbxsdk_libnames_debug})
+  find_library(
+    lib_${libname}_debug ${libname}
+    PATHS ${_fbxsdk_root}
+    PATH_SUFFIXES ${_fbxsdk_libdir_debug}
+  )
+  list(APPEND FBXSDK_LIBRARIES_DEBUG ${lib_${libname}_debug})
+endforeach()
+message(DEBUG "FBXSDK_LIBRARIES_DEBUG: ${FBXSDK_LIBRARIES_DEBUG}")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  list(APPEND FBXSDK_LIBRARIES "-framework CoreFoundation")
+  list(APPEND FBXSDK_LIBRARIES_DEBUG "-framework CoreFoundation")
+  find_package(libxml2 CONFIG QUIET)
+  find_package(iconv CONFIG QUIET)
+  list(APPEND FBXSDK_LIBRARIES LibXml2::LibXml2 Iconv::Iconv)
+  list(APPEND FBXSDK_LIBRARIES_DEBUG LibXml2::LibXml2 Iconv::Iconv)
+endif()
+
+# Set (NAME)_FOUND if all the variables and the version are satisfied.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FbxSdk
+  FAIL_MESSAGE "Failed to find FBX SDK. Please download the required FBX SDK 2020.3.7 from https://aps.autodesk.com/developer/overview/fbx-sdk. After installation, set FBXSDK_PATH to the installation directory if it's not installed to the default path."
+  REQUIRED_VARS
+    FBXSDK_INCLUDE_DIR
+    FBXSDK_LIBRARIES
+    FBXSDK_LIBRARIES_DEBUG
+  VERSION_VAR _fbxsdk_version
+)
+
+if(FbxSdk_FOUND)
+  add_library(fbxsdk::fbxsdk INTERFACE IMPORTED)
+  set_target_properties(fbxsdk::fbxsdk PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${FBXSDK_INCLUDE_DIR}"
+    INTERFACE_LINK_LIBRARIES "${FBXSDK_LIBRARIES}"
+  )
+
+  add_library(fbxsdk::fbxsdk_debug INTERFACE IMPORTED)
+  set_target_properties(fbxsdk::fbxsdk_debug PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${FBXSDK_INCLUDE_DIR}"
+    INTERFACE_LINK_LIBRARIES "${FBXSDK_LIBRARIES_DEBUG}"
+  )
+endif()

--- a/momentum/website/docs/02_user_guide/01_getting_started.md
+++ b/momentum/website/docs/02_user_guide/01_getting_started.md
@@ -104,9 +104,21 @@ pixi run clean
 
 Momentum uses the `build/` directory for CMake builds, and `.pixi/` for the Pixi virtual environment. You can clean up everything by either manually removing these directories or by running the command above.
 
-### FBX support (Windows only)
+### FBX Support
 
-Momentum uses OpenFBX to load Autodesk's FBX file format, which is built by default. To save files in FBX format, you need to install the FBX SDK 2020.3. You can download it from Autodesk's [website](https://aps.autodesk.com/developer/overview/fbx-sdk) or use [this direct link](https://damassets.autodesk.net/content/dam/autodesk/www/files/fbx202037_fbxsdk_vs2019_win.exe). After installing the SDK, build Momentum from source with `MOMENTUM_BUILD_IO_FBX=ON` option as:
+Momentum uses OpenFBX to load Autodesk's FBX file format, which is enabled by default. To save files in FBX format, you must install the FBX SDK 2020.3.
+
+#### Linux
+
+The FBX SDK will be automatically installed when you run `pixi run config`, so no additional steps are required.
+
+#### macOS
+
+Currently, building with the FBX SDK on macOS is not supported.
+
+#### Windows
+
+You can download it from Autodesk's [website](https://aps.autodesk.com/developer/overview/fbx-sdk) or use [this direct link](https://damassets.autodesk.net/content/dam/autodesk/www/files/fbx202037_fbxsdk_vs2019_win.exe). After installing the SDK, build Momentum from source with `MOMENTUM_BUILD_IO_FBX=ON` option as:
 
 ```
 # Powershell

--- a/pixi.toml
+++ b/pixi.toml
@@ -52,7 +52,7 @@ config = { cmd = """
         -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-        -DMOMENTUM_BUILD_IO_FBX=OFF \
+        -DMOMENTUM_BUILD_IO_FBX=$MOMENTUM_BUILD_IO_FBX \
         -DMOMENTUM_BUILD_TESTING=ON \
         -DMOMENTUM_BUILD_EXAMPLES=ON \
         -DMOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
@@ -60,7 +60,7 @@ config = { cmd = """
         -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
-    """, env = { MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
+    """, env = { MOMENTUM_BUILD_IO_FBX = "OFF", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
 build = { cmd = "cmake --build build -j --target all", depends_on = ["config"] }
 test = { cmd = "ctest --test-dir build --output-on-failure", depends_on = [
     "build",
@@ -86,6 +86,39 @@ pytorch = ">=2.4.0"
 sysroot_linux-64 = ">=2.28"
 
 [target.linux-64.tasks]
+# TODO: Check sha256 of fbx202037_fbxsdk_linux
+install_fbxsdk = { cmd = """
+    mkdir -p .deps \
+        && curl -fsSL https://damassets.autodesk.net/content/dam/autodesk/www/files/fbx202037_fbxsdk_gcc_linux.tar.gz -o .deps/fbx_sdk.tar.gz \
+        && mkdir -p .deps/fbxsdk_download \
+        && tar -xzf .deps/fbx_sdk.tar.gz -C .deps/fbxsdk_download \
+        && rm .deps/fbx_sdk.tar.gz \
+        && chmod ugo+x .deps/fbxsdk_download/fbx202037_fbxsdk_linux \
+        && mkdir -p .deps/fbxsdk/2020.3.7 \
+        && yes yes | .deps/fbxsdk_download/fbx202037_fbxsdk_linux .deps/fbxsdk/2020.3.7 \
+        && rm -rf .deps/fbxsdk_download/fbx202037_fbxsdk_linux
+""", outputs = [
+    ".deps/fbxsdk/2020.3.7",
+] }
+install_deps = { depends_on = ["install_fbxsdk"] }
+config = { cmd = """
+    cmake \
+        -S . \
+        -B build \
+        -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DMOMENTUM_BUILD_IO_FBX=ON \
+        -DMOMENTUM_BUILD_TESTING=ON \
+        -DMOMENTUM_BUILD_EXAMPLES=ON \
+        -DMOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
+        -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
+        -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
+        -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
+        -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
+    """, env = { FBXSDK_PATH = ".deps/fbxsdk", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" }, depends_on = [
+    "install_deps",
+] }
 build_pymomentum = { cmd = "pip install -e ." }
 test_pymomentum = { cmd = """
     pytest \


### PR DESCRIPTION
## Summary

- Add find module for FBX SDK (i.e., `FindFbxSdk.cmake`) to consolidate the find logic for multiple OSes -- macOS still doesn't work
- Install FBX SDK on Linux when running pixi tasks
- Run CI for Linux building with FBX SDK

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

Linux:
```
pixi run test  # no need to specify MOMENTUM_BUILD_IO_FBX explicitly
```

Windows:
```
$env:MOMENTUM_BUILD_IO_FBX = "ON"; pixi run test
```

macOS: not supported yet