### PR TITLE
Add debug mode to pixi tasks

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -14,26 +14,26 @@ on:
 
 jobs:
   momentum:
-    name: momentum-${{ matrix.platform }}
+    name: cpp-${{ matrix.mode == '' && 'opt' || 'dev' }}-${{ matrix.os == 'macos-latest-large' && 'mac-x86_64' || 'mac-arm64' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: macos-latest
-            platform: mac-arm
-          - os: macos-latest-large
-            platform: mac-intel
+        os: [macos-latest, macos-latest-large]
+        mode: ["", "-dev"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
           cache: true
+
       - name: Build and test Momentum
         run: |
-          pixi run test
+          pixi run test${{ matrix.mode }}
+
       - name: Install Momentum and Build hello_world
         run: |
           pixi run install
@@ -44,7 +44,7 @@ jobs:
           pixi run cmake --build momentum/examples/hello_world/build
 
   pymomentum:
-    name: pymomentum-${{ matrix.os == 'macos-latest-large' && 'mac-x86_64' || 'mac-arm64' }}
+    name: py-${{ matrix.os == 'macos-latest-large' && 'mac-x86_64' || 'mac-arm64' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -14,12 +14,13 @@ on:
 
 jobs:
   momentum:
-    name: momentum${{ matrix.simd == 'ON' && '-simd' || '' }}-ubuntu
+    name: cpp${{ matrix.simd == 'ON' && '-simd' || '' }}-${{ matrix.mode == '' && 'opt' || 'dev' }}-ubuntu
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         simd: ["ON", "OFF"]
+        mode: ["", "-dev"]
     env:
       MOMENTUM_ENABLE_SIMD: ${{ matrix.simd }}
     steps:
@@ -35,7 +36,7 @@ jobs:
         run: |
           MOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
             MOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
-            pixi run test
+            pixi run test${{ matrix.mode }}
 
       - name: Install Momentum and Build hello_world
         run: |
@@ -49,7 +50,7 @@ jobs:
           pixi run cmake --build momentum/examples/hello_world/build
 
   pymomentum:
-    name: pymomentum-${{ matrix.pixi_env }}-ubuntu
+    name: py-${{ matrix.pixi_env }}-ubuntu
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -14,18 +14,25 @@ on:
 
 jobs:
   build:
-    name: win
+    name: cpp-${{ matrix.mode == '' && 'opt' || 'dev' }}-win
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [""]  # TODO: Add -dev model
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
           cache: true
+
       - name: Build and test Momentum
         run: |
-          pixi run test
+          pixi run test${{ matrix.mode }}
+
       - name: Install Momentum and Build hello_world
         run: |
           pixi run install

--- a/pixi.toml
+++ b/pixi.toml
@@ -61,9 +61,33 @@ config = { cmd = """
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
     """, env = { MOMENTUM_BUILD_IO_FBX = "OFF", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
-build = { cmd = "cmake --build build -j --target all", depends_on = ["config"] }
+config-dev = { cmd = """
+    cmake \
+        -S . \
+        -B build \
+        -G Ninja \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DMOMENTUM_BUILD_IO_FBX=$MOMENTUM_BUILD_IO_FBX \
+        -DMOMENTUM_BUILD_TESTING=ON \
+        -DMOMENTUM_BUILD_EXAMPLES=ON \
+        -DMOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
+        -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
+        -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
+        -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
+        -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
+    """, env = { MOMENTUM_BUILD_IO_FBX = "OFF", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
+build = { cmd = "cmake --build build -j --target all", depends_on = [
+    "config",
+] }
+build-dev = { cmd = "cmake --build build -j --target all", depends_on = [
+    "config-dev",
+] }
 test = { cmd = "ctest --test-dir build --output-on-failure", depends_on = [
     "build",
+] }
+test-dev = { cmd = "ctest --test-dir build --output-on-failure", depends_on = [
+    "build-dev",
 ] }
 hello_world = { cmd = "build/hello_world", depends_on = ["build"] }
 convert_model = { cmd = "build/convert_model", depends_on = ["build"] }
@@ -207,8 +231,14 @@ open_vs = { cmd = "cmd /c start build\\momentum.sln", depends_on = ["config"] }
 build = { cmd = "cmake --build build -j --config Release", depends_on = [
     "config",
 ] }
+build-dev = { cmd = "cmake --build build -j --config Debug", depends_on = [
+    "config",
+] }
 test = { cmd = "ctest --test-dir build --output-on-failure --build-config Release", depends_on = [
     "build",
+] }
+test-dev = { cmd = "ctest --test-dir build --output-on-failure --build-config Debug", depends_on = [
+    "build-dev",
 ] }
 hello_world = { cmd = "build/Release/hello_world.exe", depends_on = ["build"] }
 convert_model = { cmd = "build/Release/convert_model.exe", depends_on = [


### PR DESCRIPTION
## Summary

- Add `{build,test}-dev` for debug mode, while `{build,test}` are the same as for release mode
- Clean up CI job names to be concise and readable (as long names are trimmed by the UI)

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

```
pixi run test
pixi run test-dev  # windows is currently broken
```
