### PR TITLE
Allow setup.py to take cmake arguments

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, macos-latest-large]
-        mode: ["", "-dev"]
+        mode: ["", "_dev"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,4 +59,4 @@ jobs:
           cache: true
       - name: Build and test PyMomentum
         run: |
-          pixi run test_pymomentum
+          pixi run test_py

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         simd: ["ON", "OFF"]
-        mode: ["", "-dev"]
+        mode: ["", "_dev"]
     env:
       MOMENTUM_ENABLE_SIMD: ${{ matrix.simd }}
     steps:
@@ -102,4 +102,4 @@ jobs:
 
       - name: Build PyMomentum
         run: |
-          pixi run -e ${{ matrix.pixi_env }} test_pymomentum
+          pixi run -e ${{ matrix.pixi_env }} test_py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,11 +59,11 @@ include(GNUInstallDirs)
 #===============================================================================
 
 mt_option(BUILD_SHARED_LIBS "Build as shared libraries" ON)
-mt_option(MOMENTUM_ENABLE_SIMD "Enable building with SIMD instructions" ON)
 mt_option(MOMENTUM_BUILD_IO_FBX "Build with IO FBX" OFF)
 mt_option(MOMENTUM_BUILD_PYMOMENTUM "Build Python binding" OFF)
 mt_option(MOMENTUM_BUILD_TESTING "Enable building tests" OFF)
 mt_option(MOMENTUM_BUILD_EXAMPLES "Enable building examples" OFF)
+mt_option(MOMENTUM_ENABLE_SIMD "Enable building with SIMD instructions" ON)
 mt_option(MOMENTUM_USE_SYSTEM_GOOGLETEST "Use GoogleTest installed in system" OFF)
 mt_option(MOMENTUM_USE_SYSTEM_PYBIND11 "Use pybind11 installed in system" OFF)
 mt_option(MOMENTUM_USE_SYSTEM_RERUN_CPP_SDK "Use Rerun C++ SDK installed in system" OFF)

--- a/cmake/FindFbxSdk.cmake
+++ b/cmake/FindFbxSdk.cmake
@@ -68,23 +68,33 @@ foreach(libname ${_fbxsdk_libnames_debug})
 endforeach()
 message(DEBUG "FBXSDK_LIBRARIES_DEBUG: ${FBXSDK_LIBRARIES_DEBUG}")
 
+set(
+  required_vars
+    FBXSDK_INCLUDE_DIR
+    FBXSDK_LIBRARIES
+    FBXSDK_LIBRARIES_DEBUG
+)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   list(APPEND FBXSDK_LIBRARIES "-framework CoreFoundation")
   list(APPEND FBXSDK_LIBRARIES_DEBUG "-framework CoreFoundation")
-  find_package(libxml2 CONFIG QUIET)
+  find_package(LibXml2 CONFIG QUIET)
   find_package(iconv CONFIG QUIET)
   list(APPEND FBXSDK_LIBRARIES LibXml2::LibXml2 Iconv::Iconv)
   list(APPEND FBXSDK_LIBRARIES_DEBUG LibXml2::LibXml2 Iconv::Iconv)
+  list(APPEND required_vars LIBXML2_LIBRARIES iconv_FOUND)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  find_package(LibXml2 MODULE QUIET)
+  list(APPEND FBXSDK_LIBRARIES LibXml2::LibXml2)
+  list(APPEND FBXSDK_LIBRARIES_DEBUG LibXml2::LibXml2)
+  list(APPEND required_vars LibXml2_FOUND)
 endif()
 
 # Set (NAME)_FOUND if all the variables and the version are satisfied.
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FbxSdk
   FAIL_MESSAGE "Failed to find FBX SDK. Please download the required FBX SDK 2020.3.7 from https://aps.autodesk.com/developer/overview/fbx-sdk. After installation, set FBXSDK_PATH to the installation directory if it's not installed to the default path."
-  REQUIRED_VARS
-    FBXSDK_INCLUDE_DIR
-    FBXSDK_LIBRARIES
-    FBXSDK_LIBRARIES_DEBUG
+  REQUIRED_VARS ${required_vars}
   VERSION_VAR _fbxsdk_version
 )
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -61,7 +61,7 @@ config = { cmd = """
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
     """, env = { MOMENTUM_BUILD_IO_FBX = "OFF", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
-config-dev = { cmd = """
+config_dev = { cmd = """
     cmake \
         -S . \
         -B build \
@@ -77,17 +77,15 @@ config-dev = { cmd = """
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
     """, env = { MOMENTUM_BUILD_IO_FBX = "OFF", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
-build = { cmd = "cmake --build build -j --target all", depends_on = [
-    "config",
-] }
-build-dev = { cmd = "cmake --build build -j --target all", depends_on = [
-    "config-dev",
+build = { cmd = "cmake --build build -j --target all", depends_on = ["config"] }
+build_dev = { cmd = "cmake --build build -j --target all", depends_on = [
+    "config_dev",
 ] }
 test = { cmd = "ctest --test-dir build --output-on-failure", depends_on = [
     "build",
 ] }
-test-dev = { cmd = "ctest --test-dir build --output-on-failure", depends_on = [
-    "build-dev",
+test_dev = { cmd = "ctest --test-dir build --output-on-failure", depends_on = [
+    "build_dev",
 ] }
 hello_world = { cmd = "build/hello_world", depends_on = ["build"] }
 convert_model = { cmd = "build/convert_model", depends_on = ["build"] }
@@ -143,8 +141,38 @@ config = { cmd = """
     """, env = { FBXSDK_PATH = ".deps/fbxsdk", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" }, depends_on = [
     "install_deps",
 ] }
-build_pymomentum = { cmd = "pip install -e ." }
-test_pymomentum = { cmd = """
+config_dev = { cmd = """
+    cmake \
+        -S . \
+        -B build \
+        -G Ninja \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DMOMENTUM_BUILD_IO_FBX=ON \
+        -DMOMENTUM_BUILD_TESTING=ON \
+        -DMOMENTUM_BUILD_EXAMPLES=ON \
+        -DMOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
+        -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
+        -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
+        -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
+        -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
+    """, env = { FBXSDK_PATH = ".deps/fbxsdk", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" }, depends_on = [
+    "install_deps",
+] }
+build_py = { cmd = """
+    python setup.py build_ext --cmake-args='\
+        -DMOMENTUM_BUILD_IO_FBX=ON \
+        -DMOMENTUM_BUILD_EXAMPLES=OFF \
+        -DMOMENTUM_BUILD_TESTING=ON \
+        -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
+        -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
+        -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
+        -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON \
+        '
+    """, env = { FBXSDK_PATH = ".deps/fbxsdk", MOMENTUM_ENABLE_SIMD = "ON" }, depends_on = [
+    "install_deps",
+] }
+test_py = { cmd = """
     pytest \
         pymomentum/test/test_closest_points.py \
         pymomentum/test/test_fbx.py \
@@ -153,7 +181,7 @@ test_pymomentum = { cmd = """
         pymomentum/test/test_skel_state.py \
         pymomentum/test/test_skeleton.py
     """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends_on = [
-    "build_pymomentum",
+    "build_py",
 ] }
 
 #============
@@ -166,9 +194,18 @@ test_pymomentum = { cmd = """
 pytorch = ">=2.4.0"
 
 [target.osx.tasks]
-build = { cmd = "cmake --build build -j --target all", depends_on = ["config"] }
-build_pymomentum = { cmd = "pip install -e ." }
-test_pymomentum = { cmd = """
+build_py = { cmd = """
+    python setup.py build_ext --cmake-args='\
+        -DMOMENTUM_BUILD_IO_FBX=OFF \
+        -DMOMENTUM_BUILD_EXAMPLES=OFF \
+        -DMOMENTUM_BUILD_TESTING=ON \
+        -DMOMENTUM_ENABLE_SIMD=ON \
+        -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
+        -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
+        -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON \
+        '
+    """ }
+test_py = { cmd = """
     pytest \
         pymomentum/test/test_closest_points.py \
         pymomentum/test/test_fbx.py \
@@ -177,7 +214,7 @@ test_pymomentum = { cmd = """
         pymomentum/test/test_skel_state.py \
         pymomentum/test/test_skeleton.py
     """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends_on = [
-    "build_pymomentum",
+    "build_py",
 ] }
 
 #============
@@ -190,9 +227,18 @@ test_pymomentum = { cmd = """
 pytorch = ">=2.4.0"
 
 [target.osx-arm64.tasks]
-build = { cmd = "cmake --build build -j --target all", depends_on = ["config"] }
-build_pymomentum = { cmd = "pip install -e ." }
-test_pymomentum = { cmd = """
+build_py = { cmd = """
+    python setup.py build_ext --cmake-args='\
+        -DMOMENTUM_BUILD_IO_FBX=OFF \
+        -DMOMENTUM_BUILD_EXAMPLES=OFF \
+        -DMOMENTUM_BUILD_TESTING=ON \
+        -DMOMENTUM_ENABLE_SIMD=ON \
+        -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
+        -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
+        -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON \
+        '
+    """ }
+test_py = { cmd = """
     pytest \
         pymomentum/test/test_closest_points.py \
         pymomentum/test/test_fbx.py \
@@ -201,7 +247,7 @@ test_pymomentum = { cmd = """
         pymomentum/test/test_skel_state.py \
         pymomentum/test/test_skeleton.py
     """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends_on = [
-    "build_pymomentum",
+    "build_py",
 ] }
 
 #=========
@@ -231,14 +277,14 @@ open_vs = { cmd = "cmd /c start build\\momentum.sln", depends_on = ["config"] }
 build = { cmd = "cmake --build build -j --config Release", depends_on = [
     "config",
 ] }
-build-dev = { cmd = "cmake --build build -j --config Debug", depends_on = [
+build_dev = { cmd = "cmake --build build -j --config Debug", depends_on = [
     "config",
 ] }
 test = { cmd = "ctest --test-dir build --output-on-failure --build-config Release", depends_on = [
     "build",
 ] }
-test-dev = { cmd = "ctest --test-dir build --output-on-failure --build-config Debug", depends_on = [
-    "build-dev",
+test_dev = { cmd = "ctest --test-dir build --output-on-failure --build-config Debug", depends_on = [
+    "build_dev",
 ] }
 hello_world = { cmd = "build/Release/hello_world.exe", depends_on = ["build"] }
 convert_model = { cmd = "build/Release/convert_model.exe", depends_on = [


### PR DESCRIPTION
## Summary

- Update `setup.py` to accept cmake arguments, making it more scalable by replacing the use of environment variables for configuring cmake options.
- Rename pixi tasks of `*_pymomentum` to `*_py` for brevity.
- Rename pixi tasks of `*-dev` to `*_dev` to follow the naming convention

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

```
pixi run test_py
```
