### PR TITLE
Add initialization for ParameterLimits.

### DIFF
--- a/momentum/character/parameter_limits.h
+++ b/momentum/character/parameter_limits.h
@@ -75,8 +75,8 @@ union LimitData {
 
 struct ParameterLimit {
   LimitData data; // limit data depending on the type
-  LimitType type; // type of limit
-  float weight; // limit weight
+  LimitType type = LimitType::MinMax; // type of limit
+  float weight = 1.0f; // limit weight
 
   inline bool operator==(const ParameterLimit& parameterLimit) const {
     return (


### PR DESCRIPTION
Summary:
While writing a test recently I discovered that the ParameterLimits class doesn't actually initialize the weight parameter.

I'm not sure there's any particular benefit to leaving it uninitialized, so to avoid future surprises let's set it to something reasonable like 1.

Reviewed By: jeongseok-meta

Differential Revision: D66489773


