### PR TITLE
Adding half-plane constraints.

### DIFF
--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -136,6 +136,13 @@ ParameterLimits mapParameterLimits(
           result.push_back(l);
         }
         break;
+      case LimitType::HalfPlane:
+        l.data.halfPlane.param1 = parameterMapping[l.data.halfPlane.param1];
+        l.data.halfPlane.param2 = parameterMapping[l.data.halfPlane.param2];
+        if (l.data.halfPlane.param1 != kInvalidIndex && l.data.halfPlane.param2 != kInvalidIndex) {
+          result.push_back(l);
+        }
+        break;
       case LimitType::Ellipsoid:
         l.data.ellipsoid.parent = jointMapping[l.data.ellipsoid.parent];
         l.data.ellipsoid.ellipsoidParent = jointMapping[l.data.ellipsoid.ellipsoidParent];

--- a/momentum/character/parameter_limits.h
+++ b/momentum/character/parameter_limits.h
@@ -21,7 +21,7 @@ namespace momentum {
 // option of modeling more complicated limits that depend on each other
 
 // limit type
-enum LimitType { MinMax, MinMaxJoint, MinMaxJointPassive, Linear, Ellipsoid };
+enum LimitType { MinMax, MinMaxJoint, MinMaxJointPassive, Linear, Ellipsoid, HalfPlane };
 
 [[nodiscard]] std::string_view toString(LimitType type);
 
@@ -36,7 +36,7 @@ struct LimitMinMaxJoint {
   Vector2f limits; // min and max values of the parameter
 };
 
-struct LimitLinear { // set joints to be similar by a linear relation i.e. p_0 = p_1 * x - o
+struct LimitLinear { // set joints to be similar by a linear relation i.e. p_0 = s * p_1 - o
   size_t referenceIndex; // index of reference parameter (p_0)
   size_t targetIndex; // index of target parameter (p_1)
   float scale; // linear scale of parameter (x)
@@ -58,11 +58,21 @@ struct LimitEllipsoid {
   size_t parent;
 };
 
+struct LimitHalfPlane {
+  // Constraint is defined by plane normal and offset as
+  //   (p1, p2) . (scale1, scale2) - offset >= 0
+  size_t param1;
+  size_t param2;
+  Vector2f normal;
+  float offset;
+};
+
 union LimitData {
   LimitMinMax minMax;
   LimitMinMaxJoint minMaxJoint;
   LimitLinear linear;
   LimitEllipsoid ellipsoid;
+  LimitHalfPlane halfPlane;
   unsigned char rawData[512];
 
   // Need to explicitly write these constructors to just copy the raw memory

--- a/momentum/character/parameter_transform.cpp
+++ b/momentum/character/parameter_transform.cpp
@@ -335,12 +335,10 @@ std::tuple<ParameterTransformT<T>, ParameterLimits> subsetParameterTransform(
     switch (limitOld.type) {
       case MinMax: {
         auto& data = limitNew.data.minMax;
-        auto paramIndexOld = data.parameterIndex;
-        auto paramIndexNew = oldParamToNewParam[paramIndexOld];
-        if (paramIndexNew == kInvalidIndex)
+        data.parameterIndex = oldParamToNewParam[data.parameterIndex];
+        if (data.parameterIndex == kInvalidIndex) {
           continue;
-
-        data.parameterIndex = paramIndexNew;
+        }
         break;
       }
 
@@ -351,17 +349,21 @@ std::tuple<ParameterTransformT<T>, ParameterLimits> subsetParameterTransform(
 
       case Linear: {
         auto& data = limitNew.data.linear;
-
-        auto referenceIndexNew = oldParamToNewParam[data.referenceIndex];
-        if (referenceIndexNew == kInvalidIndex)
+        data.referenceIndex = oldParamToNewParam[data.referenceIndex];
+        data.targetIndex = oldParamToNewParam[data.targetIndex];
+        if (data.referenceIndex == kInvalidIndex || data.targetIndex == kInvalidIndex) {
           continue;
-        data.referenceIndex = (int)referenceIndexNew;
+        }
+        break;
+      }
 
-        auto targetIndexNew = oldParamToNewParam[data.targetIndex];
-        if (targetIndexNew == kInvalidIndex)
+      case HalfPlane: {
+        auto& data = limitNew.data.halfPlane;
+        data.param1 = oldParamToNewParam[data.param1];
+        data.param2 = oldParamToNewParam[data.param2];
+        if (data.param1 == kInvalidIndex || data.param2 == kInvalidIndex) {
           continue;
-        data.targetIndex = (int)targetIndexNew;
-
+        }
         break;
       }
 

--- a/momentum/io/gltf/utils/json_utils.cpp
+++ b/momentum/io/gltf/utils/json_utils.cpp
@@ -210,6 +210,13 @@ void parameterLimitsToJson(const Character& character, nlohmann::json& j) {
         li["scale"] = lim.data.linear.scale;
         li["offset"] = lim.data.linear.offset;
         break;
+      case HalfPlane:
+        li["type"] = "half_plane";
+        li["param1"] = character.parameterTransform.name[lim.data.halfPlane.param1];
+        li["param2"] = character.parameterTransform.name[lim.data.halfPlane.param2];
+        li["normal"] = lim.data.halfPlane.normal;
+        li["offset"] = lim.data.halfPlane.offset;
+        break;
       case Ellipsoid: {
         li["type"] = "ellipsoid";
         li["parent"] = character.skeleton.joints[lim.data.ellipsoid.parent].name;
@@ -279,6 +286,14 @@ ParameterLimits parameterLimitsFromJson(const Character& character, const nlohma
           character.parameterTransform.getParameterIdByName(element.value("targetParameter", ""));
       l.data.linear.scale = element["scale"];
       l.data.linear.offset = element["offset"];
+    } else if (type == "half_plane") {
+      l.type = HalfPlane;
+      l.data.halfPlane.param1 =
+          character.parameterTransform.getParameterIdByName(element.value("param1", ""));
+      l.data.halfPlane.param2 =
+          character.parameterTransform.getParameterIdByName(element.value("param2", ""));
+      l.data.halfPlane.normal = fromJson<Vector2f>(element["normal"]);
+      l.data.halfPlane.offset = element["offset"];
     } else if (type == "ellipsoid") {
       l.type = Ellipsoid;
       l.data.ellipsoid.parent = character.skeleton.getJointIdByName(element.value("parent", ""));

--- a/momentum/test/io/io_parameter_limits_test.cpp
+++ b/momentum/test/io/io_parameter_limits_test.cpp
@@ -156,6 +156,17 @@ Character createCharacterWithLimits() {
     limits.push_back(limit);
   }
 
+  {
+    ParameterLimit limit;
+    limit.type = LimitType::HalfPlane;
+    limit.weight = 3.5;
+    limit.data.halfPlane.param1 = 1;
+    limit.data.halfPlane.param2 = 3;
+    limit.data.halfPlane.normal = Eigen::Vector2f(1, -1).normalized();
+    limit.data.halfPlane.offset = 0.7f;
+    limits.push_back(limit);
+  }
+
   return {testCharacter.skeleton, testCharacter.parameterTransform, limits};
 }
 
@@ -208,6 +219,13 @@ void validateParameterLimitsSame(const ParameterLimits& limits1, const Parameter
         EXPECT_EQ(l1.data.ellipsoid.ellipsoidParent, l2.data.ellipsoid.ellipsoidParent);
         EXPECT_EQ(l1.data.ellipsoid.parent, l2.data.ellipsoid.parent);
         EXPECT_LE((l1.data.ellipsoid.offset - l2.data.ellipsoid.offset).norm(), 1e-4f);
+        break;
+
+      case LimitType::HalfPlane:
+        EXPECT_LE((l1.data.halfPlane.normal - l2.data.halfPlane.normal).norm(), 1e-4f);
+        EXPECT_NEAR(l1.data.halfPlane.offset, l2.data.halfPlane.offset, 1e-4f);
+        EXPECT_EQ(l1.data.halfPlane.param1, l2.data.halfPlane.param1);
+        EXPECT_EQ(l1.data.halfPlane.param2, l2.data.halfPlane.param2);
         break;
     }
   }


### PR DESCRIPTION
Summary:
We want to structure certain shoulder constraints as half-plane constraints, that is, a*p1 + b*p2 - c >= 0.  This will allow us to cave out regions of the space where the parameters need to act together, for example, (p1 - p2 >= 0) means p1 should always be at least as big as p2.  

Note that we are not bothering to implement this in a piecewise fashion like we did linear constraints because you can always carve out an arbitrary convex volume with a set of half-plane constraints.  One possible extension might be to allow using more than 2 variables in the plane equation if desired.  

Note that here instead of trying to single out a "targetParameter" and "referenceParameter" like we use in the linear constraint I'm just using "param1" and "param2" to emphasize the symmetry between the parameters, but I could be convinced otherwise if people want something different.

Differential Revision: D66522514


