### PR TITLE
Update gltf io to support half plane constraint limit

### DIFF
--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -136,6 +136,13 @@ ParameterLimits mapParameterLimits(
           result.push_back(l);
         }
         break;
+      case LimitType::HalfPlane:
+        l.data.halfPlane.param1 = parameterMapping[l.data.halfPlane.param1];
+        l.data.halfPlane.param2 = parameterMapping[l.data.halfPlane.param2];
+        if (l.data.halfPlane.param1 != kInvalidIndex && l.data.halfPlane.param2 != kInvalidIndex) {
+          result.push_back(l);
+        }
+        break;
       case LimitType::Ellipsoid:
         l.data.ellipsoid.parent = jointMapping[l.data.ellipsoid.parent];
         l.data.ellipsoid.ellipsoidParent = jointMapping[l.data.ellipsoid.ellipsoidParent];

--- a/momentum/character/parameter_limits.h
+++ b/momentum/character/parameter_limits.h
@@ -21,7 +21,7 @@ namespace momentum {
 // option of modeling more complicated limits that depend on each other
 
 // limit type
-enum LimitType { MinMax, MinMaxJoint, MinMaxJointPassive, Linear, Ellipsoid };
+enum LimitType { MinMax, MinMaxJoint, MinMaxJointPassive, Linear, Ellipsoid, HalfPlane };
 
 [[nodiscard]] std::string_view toString(LimitType type);
 
@@ -36,7 +36,7 @@ struct LimitMinMaxJoint {
   Vector2f limits; // min and max values of the parameter
 };
 
-struct LimitLinear { // set joints to be similar by a linear relation i.e. p_0 = p_1 * x - o
+struct LimitLinear { // set joints to be similar by a linear relation i.e. p_0 = s * p_1 - o
   size_t referenceIndex; // index of reference parameter (p_0)
   size_t targetIndex; // index of target parameter (p_1)
   float scale; // linear scale of parameter (x)
@@ -58,11 +58,21 @@ struct LimitEllipsoid {
   size_t parent;
 };
 
+struct LimitHalfPlane {
+  // Constraint is defined by plane normal and offset as
+  //   (p1, p2) . (scale1, scale2) - offset >= 0
+  size_t param1;
+  size_t param2;
+  Vector2f normal;
+  float offset;
+};
+
 union LimitData {
   LimitMinMax minMax;
   LimitMinMaxJoint minMaxJoint;
   LimitLinear linear;
   LimitEllipsoid ellipsoid;
+  LimitHalfPlane halfPlane;
   unsigned char rawData[512];
 
   // Need to explicitly write these constructors to just copy the raw memory

--- a/momentum/character/parameter_transform.cpp
+++ b/momentum/character/parameter_transform.cpp
@@ -335,12 +335,10 @@ std::tuple<ParameterTransformT<T>, ParameterLimits> subsetParameterTransform(
     switch (limitOld.type) {
       case MinMax: {
         auto& data = limitNew.data.minMax;
-        auto paramIndexOld = data.parameterIndex;
-        auto paramIndexNew = oldParamToNewParam[paramIndexOld];
-        if (paramIndexNew == kInvalidIndex)
+        data.parameterIndex = oldParamToNewParam[data.parameterIndex];
+        if (data.parameterIndex == kInvalidIndex) {
           continue;
-
-        data.parameterIndex = paramIndexNew;
+        }
         break;
       }
 
@@ -351,17 +349,21 @@ std::tuple<ParameterTransformT<T>, ParameterLimits> subsetParameterTransform(
 
       case Linear: {
         auto& data = limitNew.data.linear;
-
-        auto referenceIndexNew = oldParamToNewParam[data.referenceIndex];
-        if (referenceIndexNew == kInvalidIndex)
+        data.referenceIndex = oldParamToNewParam[data.referenceIndex];
+        data.targetIndex = oldParamToNewParam[data.targetIndex];
+        if (data.referenceIndex == kInvalidIndex || data.targetIndex == kInvalidIndex) {
           continue;
-        data.referenceIndex = (int)referenceIndexNew;
+        }
+        break;
+      }
 
-        auto targetIndexNew = oldParamToNewParam[data.targetIndex];
-        if (targetIndexNew == kInvalidIndex)
+      case HalfPlane: {
+        auto& data = limitNew.data.halfPlane;
+        data.param1 = oldParamToNewParam[data.param1];
+        data.param2 = oldParamToNewParam[data.param2];
+        if (data.param1 == kInvalidIndex || data.param2 == kInvalidIndex) {
           continue;
-        data.targetIndex = (int)targetIndexNew;
-
+        }
         break;
       }
 

--- a/momentum/character_solver/limit_error_function.cpp
+++ b/momentum/character_solver/limit_error_function.cpp
@@ -103,6 +103,21 @@ double LimitErrorFunctionT<T>::getError(
         }
         break;
       }
+      case HalfPlane: {
+        const auto& data = limit.data.halfPlane;
+        MT_CHECK(data.param1 < static_cast<size_t>(params.size()));
+        MT_CHECK(data.param2 < static_cast<size_t>(params.size()));
+
+        if ((this->enabledParameters_.test(data.param1) ||
+             this->enabledParameters_.test(data.param2))) {
+          const Eigen::Vector2<T> p(params(data.param1), params(data.param2));
+          const T residual = p.dot(data.normal.cast<T>()) - data.offset;
+          if (residual < 0) {
+            error += residual * residual * limit.weight;
+          }
+        }
+        break;
+      }
       case Ellipsoid: {
         const auto& ct = limit.data.ellipsoid;
 
@@ -228,6 +243,25 @@ double LimitErrorFunctionT<T>::getGradient(
           }
           if (this->enabledParameters_.test(data.referenceIndex)) {
             gradient[data.referenceIndex] -= T(2) * residual * tWeight;
+          }
+        }
+        break;
+      }
+      case HalfPlane: {
+        const auto& data = limit.data.halfPlane;
+        if ((this->enabledParameters_.test(data.param1) ||
+             this->enabledParameters_.test(data.param2))) {
+          const Eigen::Vector2<T> p(params(data.param1), params(data.param2));
+          const T residual = p.dot(data.normal.cast<T>()) - data.offset;
+          if (residual < 0.0f) {
+            error += residual * residual * limit.weight * tWeight;
+
+            if (this->enabledParameters_.test(data.param1)) {
+              gradient[data.param1] += T(2) * residual * data.normal[0] * tWeight;
+            }
+            if (this->enabledParameters_.test(data.param2)) {
+              gradient[data.param2] += T(2) * residual * data.normal[1] * tWeight;
+            }
           }
         }
         break;
@@ -431,6 +465,31 @@ double LimitErrorFunctionT<T>::getJacobian(
         count++;
         break;
       }
+      case HalfPlane: {
+        const auto& data = limit.data.halfPlane;
+        MT_CHECK(data.param1 < static_cast<size_t>(params.size()));
+        MT_CHECK(data.param2 < static_cast<size_t>(params.size()));
+
+        if ((this->enabledParameters_.test(data.param1) ||
+             this->enabledParameters_.test(data.param2))) {
+          const Eigen::Vector2<T> p(params(data.param1), params(data.param2));
+          const T res = p.dot(data.normal.cast<T>()) - data.offset;
+          if (res < 0) {
+            error += res * res * limit.weight * tWeight;
+            residual(count) = res * wgt;
+
+            if (this->enabledParameters_.test(data.param1)) {
+              jacobian(count, data.param1) = data.normal[0] * wgt;
+            }
+
+            if (this->enabledParameters_.test(data.param2)) {
+              jacobian(count, data.param2) = data.normal[1] * wgt;
+            }
+          }
+        }
+        count++;
+        break;
+      }
       case Ellipsoid: {
         // NOTE: The jacobian for these is currently simplified
         // It assumes the ellipsoid is static and doesn't move with the parent joint
@@ -543,12 +602,11 @@ size_t LimitErrorFunctionT<T>::getJacobianSize() const {
       case Linear:
         count++;
         break;
+      case HalfPlane:
+        count++;
+        break;
       case Ellipsoid:
         count += 3;
-        break;
-      default:
-        // should never get here
-        MT_THROW("Unknown parameter type for joint limit");
         break;
     }
   }

--- a/momentum/io/gltf/utils/json_utils.cpp
+++ b/momentum/io/gltf/utils/json_utils.cpp
@@ -210,6 +210,13 @@ void parameterLimitsToJson(const Character& character, nlohmann::json& j) {
         li["scale"] = lim.data.linear.scale;
         li["offset"] = lim.data.linear.offset;
         break;
+      case HalfPlane:
+        li["type"] = "half_plane";
+        li["param1"] = character.parameterTransform.name[lim.data.halfPlane.param1];
+        li["param2"] = character.parameterTransform.name[lim.data.halfPlane.param2];
+        li["normal"] = lim.data.halfPlane.normal;
+        li["offset"] = lim.data.halfPlane.offset;
+        break;
       case Ellipsoid: {
         li["type"] = "ellipsoid";
         li["parent"] = character.skeleton.joints[lim.data.ellipsoid.parent].name;
@@ -279,6 +286,14 @@ ParameterLimits parameterLimitsFromJson(const Character& character, const nlohma
           character.parameterTransform.getParameterIdByName(element.value("targetParameter", ""));
       l.data.linear.scale = element["scale"];
       l.data.linear.offset = element["offset"];
+    } else if (type == "half_plane") {
+      l.type = HalfPlane;
+      l.data.halfPlane.param1 =
+          character.parameterTransform.getParameterIdByName(element.value("param1", ""));
+      l.data.halfPlane.param2 =
+          character.parameterTransform.getParameterIdByName(element.value("param2", ""));
+      l.data.halfPlane.normal = fromJson<Vector2f>(element["normal"]);
+      l.data.halfPlane.offset = element["offset"];
     } else if (type == "ellipsoid") {
       l.type = Ellipsoid;
       l.data.ellipsoid.parent = character.skeleton.getJointIdByName(element.value("parent", ""));

--- a/momentum/test/io/io_parameter_limits_test.cpp
+++ b/momentum/test/io/io_parameter_limits_test.cpp
@@ -156,6 +156,17 @@ Character createCharacterWithLimits() {
     limits.push_back(limit);
   }
 
+  {
+    ParameterLimit limit;
+    limit.type = LimitType::HalfPlane;
+    limit.weight = 3.5;
+    limit.data.halfPlane.param1 = 1;
+    limit.data.halfPlane.param2 = 3;
+    limit.data.halfPlane.normal = Eigen::Vector2f(1, -1).normalized();
+    limit.data.halfPlane.offset = 0.7f;
+    limits.push_back(limit);
+  }
+
   return {testCharacter.skeleton, testCharacter.parameterTransform, limits};
 }
 
@@ -208,6 +219,13 @@ void validateParameterLimitsSame(const ParameterLimits& limits1, const Parameter
         EXPECT_EQ(l1.data.ellipsoid.ellipsoidParent, l2.data.ellipsoid.ellipsoidParent);
         EXPECT_EQ(l1.data.ellipsoid.parent, l2.data.ellipsoid.parent);
         EXPECT_LE((l1.data.ellipsoid.offset - l2.data.ellipsoid.offset).norm(), 1e-4f);
+        break;
+
+      case LimitType::HalfPlane:
+        EXPECT_LE((l1.data.halfPlane.normal - l2.data.halfPlane.normal).norm(), 1e-4f);
+        EXPECT_NEAR(l1.data.halfPlane.offset, l2.data.halfPlane.offset, 1e-4f);
+        EXPECT_EQ(l1.data.halfPlane.param1, l2.data.halfPlane.param1);
+        EXPECT_EQ(l1.data.halfPlane.param2, l2.data.halfPlane.param2);
         break;
     }
   }

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -73,7 +73,8 @@ PYBIND11_MODULE(geometry, m) {
       .value("MinMaxJoint", mm::LimitType::MinMaxJoint)
       .value("MinMaxJointPassive", mm::LimitType::MinMaxJointPassive)
       .value("Linear", mm::LimitType::Linear)
-      .value("Ellipsoid", mm::LimitType::Ellipsoid);
+      .value("Ellipsoid", mm::LimitType::Ellipsoid)
+      .value("HalfPlane", mm::LimitType::HalfPlane);
 
   // We need to forward-declare classes so that if we refer to them they get
   // typed correctly; otherwise we end up with "momentum::Locator" in the
@@ -109,6 +110,8 @@ PYBIND11_MODULE(geometry, m) {
       py::class_<mm::LimitMinMaxJoint>(m, "LimitMinMaxJoint");
   auto parameterLimitLinearClass =
       py::class_<mm::LimitLinear>(m, "LimitLinear");
+  auto parameterLimitHalfPlaneClass =
+      py::class_<mm::LimitHalfPlane>(m, "LimitHalfPlane");
   auto parameterLimitEllipsoidClass =
       py::class_<mm::LimitEllipsoid>(m, "LimitEllipsoid");
 
@@ -1219,6 +1222,34 @@ Create a parameter limit with min and max values for a joint parameter.
           py::arg("range_min") = std::optional<float>{},
           py::arg("range_max") = std::optional<float>{})
       .def_static(
+          "create_halfplane",
+          [](size_t param1,
+             size_t param2,
+             Eigen::Vector2f normal,
+             float offset,
+             float weight) {
+            mm::LimitData data;
+            data.halfPlane.param1 = param1;
+            data.halfPlane.param2 = param2;
+
+            const float len = normal.norm();
+            data.halfPlane.normal = normal / len;
+            data.halfPlane.offset = offset / len;
+            return mm::ParameterLimit{data, mm::LimitType::HalfPlane, weight};
+          },
+          R"(Create a parameter limit with a half-plane constraint.
+
+:parameter param1_index: Index of the first parameter in the plane equation (p1, p2) . (n1, n2) - offset >= 0.
+:parameter param2_index: Index of the second parameter (p1, p2) . (n1, n2) - offset >= 0.
+:parameter offset: Offset to use in equation (p1, p2) . (n1, n2) - offset >= 0.
+:parameter weight: Weight of the parameter limit.  Defaults to 1.
+    )",
+          py::arg("param1_index"),
+          py::arg("param2_index"),
+          py::arg("normal"),
+          py::arg("offset") = 0.0f,
+          py::arg("weight") = 1.0f)
+      .def_static(
           "create_ellipsoid",
           [](size_t ellipsoid_parent,
              size_t parent,
@@ -1254,6 +1285,8 @@ Create a parameter limit with min and max values for a joint parameter.
           &mm::LimitData::minMaxJoint,
           "Data for MinMaxJoint limit.")
       .def_readonly("linear", &mm::LimitData::linear, "Data for Linear limit.")
+      .def_readonly(
+          "halfplane", &mm::LimitData::halfPlane, "Data for HalfPlane limit.")
       .def_readonly(
           "ellipsoid", &mm::LimitData::ellipsoid, "Data for Ellipsoid limit.");
 
@@ -1323,6 +1356,12 @@ Create a parameter limit with min and max values for a joint parameter.
               return std::make_optional(data.rangeMax);
             }
           });
+
+  parameterLimitHalfPlaneClass
+      .def_readonly("param1_index", &mm::LimitHalfPlane::param1)
+      .def_readonly("param2_index", &mm::LimitHalfPlane::param2)
+      .def_readonly("offset", &mm::LimitHalfPlane::offset)
+      .def_readonly("normal", &mm::LimitHalfPlane::normal);
 
   parameterLimitEllipsoidClass
       .def_property_readonly(


### PR DESCRIPTION
Summary: Support half plane parameter limits in gltf io so we can read/write glb files with the new .model definition.

Differential Revision: D66556291


