### PR TITLE
Additional control over simplification.

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -81,7 +81,9 @@ config_dev = { cmd = """
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
     """, env = { MOMENTUM_BUILD_IO_FBX = "OFF", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
-build = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --target all", depends_on = ["config"] }
+build = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --target all", depends_on = [
+    "config",
+] }
 build_dev = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/debug -j --target all", depends_on = [
     "config_dev",
 ] }
@@ -106,7 +108,7 @@ install = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --t
 #===========
 
 [target.linux-64.build-dependencies]
-nvtx-c = ">=3.1.0"  # TODO: Add to pytorch as run dep
+nvtx-c = ">=3.1.0" # TODO: Add to pytorch as run dep
 
 [target.linux-64.dependencies]
 pytorch = ">=2.4.0"
@@ -340,48 +342,42 @@ channels = ["nvidia", "conda-forge", "pytorch"]
 platforms = ["linux-64"]
 system-requirements = { cuda = "12.0" }
 channel-priority = "disabled"
-dependencies.cuda-toolkit = "12.*"
-dependencies.pytorch = { version = "2.5.*", build = "cuda126_py312*", channel = "conda-forge" }
+dependencies = { cuda-toolkit = "12.*", pytorch = { version = "2.5.*", build = "cuda126_py312*", channel = "conda-forge" } }
 
 [feature.py312-cuda118]
 channels = ["nvidia", "conda-forge", "pytorch"]
 platforms = ["linux-64"]
 system-requirements = { cuda = "12.0" }
 channel-priority = "disabled"
-dependencies.cuda-toolkit = "12.*"
-dependencies.pytorch = { version = "2.5.*", build = "cuda118_py312*", channel = "conda-forge" }
+dependencies = { cuda-toolkit = "12.*", pytorch = { version = "2.5.*", build = "cuda118_py312*", channel = "conda-forge" } }
 
 [feature.py311-cuda126]
 channels = ["nvidia", "conda-forge", "pytorch"]
 platforms = ["linux-64"]
 system-requirements = { cuda = "12.0" }
 channel-priority = "disabled"
-dependencies.cuda-toolkit = "12.*"
-dependencies.pytorch = { version = "2.5.*", build = "cuda126_py311*", channel = "conda-forge" }
+dependencies = { cuda-toolkit = "12.*", pytorch = { version = "2.5.*", build = "cuda126_py311*", channel = "conda-forge" } }
 
 [feature.py311-cuda118]
 channels = ["nvidia", "conda-forge", "pytorch"]
 platforms = ["linux-64"]
 system-requirements = { cuda = "12.0" }
 channel-priority = "disabled"
-dependencies.cuda-toolkit = "12.*"
-dependencies.pytorch = { version = "2.5.*", build = "cuda118_py311*", channel = "conda-forge" }
+dependencies = { cuda-toolkit = "12.*", pytorch = { version = "2.5.*", build = "cuda118_py311*", channel = "conda-forge" } }
 
 [feature.py310-cuda126]
 channels = ["nvidia", "conda-forge", "pytorch"]
 platforms = ["linux-64"]
 system-requirements = { cuda = "12.0" }
 channel-priority = "disabled"
-dependencies.cuda-toolkit = "12.*"
-dependencies.pytorch = { version = "2.5.*", build = "cuda126_py310*", channel = "conda-forge" }
+dependencies = { cuda-toolkit = "12.*", pytorch = { version = "2.5.*", build = "cuda126_py310*", channel = "conda-forge" } }
 
 [feature.py310-cuda118]
 channels = ["nvidia", "conda-forge", "pytorch"]
 platforms = ["linux-64"]
 system-requirements = { cuda = "12.0" }
 channel-priority = "disabled"
-dependencies.cuda-toolkit = "12.*"
-dependencies.pytorch = { version = "2.5.*", build = "cuda118_py310*", channel = "conda-forge" }
+dependencies = { cuda-toolkit = "12.*", pytorch = { version = "2.5.*", build = "cuda118_py310*", channel = "conda-forge" } }
 
 #==============
 # Environments

--- a/pymomentum/geometry/momentum_geometry.h
+++ b/pymomentum/geometry/momentum_geometry.h
@@ -113,10 +113,6 @@ std::shared_ptr<momentum::BlendShape> loadBlendShapeFromTensors(
 momentum::Character stripLowerBodyVertices(
     const momentum::Character& character);
 
-std::unique_ptr<momentum::Character> reduceToSelectedModelParameters(
-    const momentum::Character& character,
-    at::Tensor activeParams);
-
 std::vector<size_t> getUpperBodyJoints(const momentum::Skeleton& skeleton);
 
 std::tuple<float, Eigen::VectorXf, Eigen::MatrixXf, float> getMppcaModel(
@@ -171,6 +167,11 @@ std::unique_ptr<momentum::Mesh> getPosedMesh(
 momentum::Character replaceRestMesh(
     const momentum::Character& character,
     RowMatrixf positions);
+
+std::vector<bool> jointListToBitset(
+    const momentum::Character& character,
+    const std::vector<int>& jointIndices);
+std::vector<int> bitsetToJointList(const std::vector<bool>& jointMask);
 
 /// Matches the locator names from the available locators in the character
 /// object and returns parents and offsets for the each of the locator names


### PR DESCRIPTION
Summary:
We expose the simplify() function which is a way to reduce the size of the skeleton to make FK/IK more efficient.  However, we have found that it does not provide enough granularity for what people want, so we added separate simplifySkeleton() and simplifyParameterTransform() functions to c++ momentum.  Let's expose those out through pymomentum.  

Note that simplifyParameterTransform was already available through the reduce_to_selected_model_parameters() function, but IMO that naming is not ideal and it's not sufficiently discoverable.  Having simplify_skeleton and simplify_parameter_transform functions seems like a better way to go in the long run, and we should eventually deprecate the reduce_to_selected_model_parameters() function.

Also changing some of the asserts in simplifySkeleton() to exceptions, since in calling code it would not be unexpected to forget to include a parent joint in a simplified skeleton, so we should not completely kill the process.

Differential Revision: D66664436


