### PR TITLE
GLTF support for writing directly to a buffer.

### DIFF
--- a/momentum/io/gltf/gltf_io.cpp
+++ b/momentum/io/gltf/gltf_io.cpp
@@ -1063,4 +1063,25 @@ void saveCharacter(
   GltfBuilder::save(model, filename, fileFormat, kEmbedResources);
 }
 
+std::vector<std::byte> saveCharacterToBytes(
+    const Character& character,
+    float fps,
+    const MotionParameters& motion,
+    const IdentityParameters& offsets,
+    const std::vector<std::vector<Marker>>& markerSequence) {
+  constexpr auto kEmbedResources = false; // Don't embed resource for saving glb
+  fx::gltf::Document model =
+      makeCharacterDocument(character, fps, motion, offsets, markerSequence, kEmbedResources);
+
+  std::ostringstream output(std::ios::binary | std::ios::out);
+  fx::gltf::Save(model, output, {}, true);
+  const auto view = output.str();
+  const auto n = view.size();
+  std::vector<std::byte> result(n);
+  for (size_t i = 0; i < n; ++i) {
+    result[i] = static_cast<std::byte>(view[i]);
+  }
+  return result;
+}
+
 } // namespace momentum

--- a/momentum/io/gltf/gltf_io.h
+++ b/momentum/io/gltf/gltf_io.h
@@ -115,4 +115,11 @@ void saveCharacter(
     const std::vector<std::vector<Marker>>& markerSequence = {},
     GltfFileFormat fileFormat = GltfFileFormat::Extension);
 
+std::vector<std::byte> saveCharacterToBytes(
+    const Character& character,
+    float fps = 120.0f,
+    const MotionParameters& motion = {},
+    const IdentityParameters& offsets = {},
+    const std::vector<std::vector<Marker>>& markerSequence = {});
+
 } // namespace momentum


### PR DESCRIPTION
Summary: We want to be able to read and write GLTF without ever writing anything to disk.   The current code doesn't support it but we can add a simple wrapper.

Reviewed By: jeongseok-meta

Differential Revision: D66258220


