### PR TITLE
Add io_skeleton_test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,6 +636,15 @@ if(MOMENTUM_BUILD_TESTING)
     ENV
       "TEST_RESOURCES_PATH=${CMAKE_SOURCE_DIR}/momentum/test/resources"
   )
+
+  mt_test(
+    NAME io_skeleton_test
+    SOURCES_VARS io_skeleton_test_sources
+    LINK_LIBRARIES
+      character_test_helper
+      io_skeleton
+      io_test_helper
+  )
 endif()
 
 #===============================================================================

--- a/momentum/test/io/io_parameter_limits_test.cpp
+++ b/momentum/test/io/io_parameter_limits_test.cpp
@@ -54,7 +54,7 @@ Character createCharacterWithLimits() {
     limit.weight = 4.0;
     limit.data.ellipsoid.ellipsoid = limit.data.ellipsoid.ellipsoid = Affine3f::Identity();
     limit.data.ellipsoid.ellipsoid.translation() = Eigen::Vector3f(2, 3, 4);
-    const Vector3f eulerXYZ = Vector3f(M_PI / 2.0, M_PI / 4.0, -M_PI / 3.0);
+    const Vector3f eulerXYZ = Vector3f(pi() / 2.0f, pi() / 4.0f, -pi() / 3.0f);
     limit.data.ellipsoid.ellipsoid.linear() =
         eulerXYZToRotationMatrix(eulerXYZ, EulerConvention::Extrinsic) *
         Eigen::Scaling(0.8f, 0.9f, 1.3f);
@@ -72,7 +72,7 @@ Character createCharacterWithLimits() {
     limit.weight = 5.0;
     limit.data.ellipsoid.ellipsoid = limit.data.ellipsoid.ellipsoid = Affine3f::Identity();
     limit.data.ellipsoid.ellipsoid.translation() = Eigen::Vector3f(2, 3, 4);
-    const Vector3f eulerXYZ = Vector3f(-M_PI / 4.0, 2.0f * M_PI / 4.0, M_PI / 3.0);
+    const Vector3f eulerXYZ = Vector3f(-pi() / 4.0f, 2.0f * pi() / 4.0f, pi() / 3.0f);
     limit.data.ellipsoid.ellipsoid.linear() =
         eulerXYZToRotationMatrix(eulerXYZ, EulerConvention::Extrinsic) *
         Eigen::Scaling(2.0f, 0.4f, 0.6f);


### PR DESCRIPTION
## Summary

- Add `io_skeleton_test` for the recently added [io_parameter_limits_test.cpp](https://github.com/facebookincubator/momentum/pull/135/files#diff-f57dacf327b6f074b5639057ca505434e44fd6e5b16abced92c5e7316c05dee4) by #135
- Change `M_PI` with a portable function, `pi()`

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

```
pixi run test
```
