### PR TITLE
Rename character_test_helper to character_test_helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,9 +476,9 @@ if(MOMENTUM_BUILD_TESTING)
   )
 
   mt_library(
-    NAME character_test_helper
-    HEADERS_VARS character_test_helper_public_headers
-    SOURCES_VARS character_test_helper_sources
+    NAME character_test_helpers
+    HEADERS_VARS character_test_helpers_public_headers
+    SOURCES_VARS character_test_helpers_sources
     PUBLIC_LINK_LIBRARIES
       character
     PRIVATE_LINK_LIBRARIES
@@ -570,7 +570,7 @@ if(MOMENTUM_BUILD_TESTING)
     SOURCES_VARS character_test_sources
     LINK_LIBRARIES
       character
-      character_test_helper
+      character_test_helpers
       test_helpers
   )
 
@@ -579,7 +579,7 @@ if(MOMENTUM_BUILD_TESTING)
     SOURCES_VARS character_solver_test_sources
     LINK_LIBRARIES
       character_solver
-      character_test_helper
+      character_test_helpers
       error_function_helper
       solver_test_helper
   )
@@ -590,7 +590,7 @@ if(MOMENTUM_BUILD_TESTING)
       SOURCES_VARS simd_constraints_test_sources
       LINK_LIBRARIES
         character_solver
-        character_test_helper
+        character_test_helpers
         error_function_helper
         simd_constraints
     )
@@ -601,7 +601,7 @@ if(MOMENTUM_BUILD_TESTING)
     SOURCES_VARS character_sequence_solver_test_sources
     LINK_LIBRARIES
       character_sequence_solver
-      character_test_helper
+      character_test_helpers
       solver_test_helper
   )
 
@@ -612,7 +612,7 @@ if(MOMENTUM_BUILD_TESTING)
       HEADERS_VARS diff_ik_test_headers
       SOURCES_VARS diff_ik_test_sources
       LINK_LIBRARIES
-        character_test_helper
+        character_test_helpers
         diff_ik
         io_gltf
         io_skeleton
@@ -641,7 +641,7 @@ if(MOMENTUM_BUILD_TESTING)
     NAME io_skeleton_test
     SOURCES_VARS io_skeleton_test_sources
     LINK_LIBRARIES
-      character_test_helper
+      character_test_helpers
       io_skeleton
       io_test_helper
   )

--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -456,11 +456,11 @@ test_helpers_sources = [
     "test/helpers/unique_temporary_file.cpp",
 ]
 
-character_test_helper_public_headers = [
+character_test_helpers_public_headers = [
     "test/character/character_helpers.h",
 ]
 
-character_test_helper_sources = [
+character_test_helpers_sources = [
     "test/character/character_helpers.cpp",
 ]
 

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -175,7 +175,7 @@ if(MOMENTUM_BUILD_TESTING)
     PYMOMENTUM_SOURCES_VARS geometry_test_helper_sources
     INCLUDE_DIRECTORIES
     LINK_LIBRARIES
-      character_test_helper
+      character_test_helpers
   )
 
   mt_test(


### PR DESCRIPTION
Summary: To have consistent name convention with other test helper targets (e.g., `test_helpers`)

Differential Revision: D66787080


