### PR TITLE
Adding linearJoint constraint.

### DIFF
--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -136,6 +136,15 @@ ParameterLimits mapParameterLimits(
           result.push_back(l);
         }
         break;
+      case LimitType::LinearJoint:
+        l.data.linearJoint.referenceJointIndex =
+            parameterMapping[l.data.linearJoint.referenceJointIndex];
+        l.data.linearJoint.targetJointIndex = parameterMapping[l.data.linearJoint.targetJointIndex];
+        if (l.data.linearJoint.referenceJointIndex != kInvalidIndex &&
+            l.data.linearJoint.targetJointIndex != kInvalidIndex) {
+          result.push_back(l);
+        }
+        break;
       case LimitType::HalfPlane:
         l.data.halfPlane.param1 = parameterMapping[l.data.halfPlane.param1];
         l.data.halfPlane.param2 = parameterMapping[l.data.halfPlane.param2];

--- a/momentum/character/parameter_limits.cpp
+++ b/momentum/character/parameter_limits.cpp
@@ -103,4 +103,14 @@ bool isInRange(const LimitLinear& limit, float value) {
   return value >= limit.rangeMin && value < limit.rangeMax;
 }
 
+bool isInRange(const LimitLinearJoint& limit, float value) {
+  // Default initialized limits have all zeros in their members due to the std::fill_n above
+  // but we want in this case to have the limit apply across the entire range of values:
+  if (limit.rangeMin == 0 && limit.rangeMax == 0) {
+    return true;
+  }
+
+  return value >= limit.rangeMin && value < limit.rangeMax;
+}
+
 } // namespace momentum

--- a/momentum/character/parameter_limits.h
+++ b/momentum/character/parameter_limits.h
@@ -21,7 +21,15 @@ namespace momentum {
 // option of modeling more complicated limits that depend on each other
 
 // limit type
-enum LimitType { MinMax, MinMaxJoint, MinMaxJointPassive, Linear, Ellipsoid, HalfPlane };
+enum LimitType {
+  MinMax,
+  MinMaxJoint,
+  MinMaxJointPassive,
+  Linear,
+  LinearJoint,
+  Ellipsoid,
+  HalfPlane
+};
 
 [[nodiscard]] std::string_view toString(LimitType type);
 
@@ -50,6 +58,18 @@ struct LimitLinear { // set joints to be similar by a linear relation i.e. p_0 =
   float rangeMax;
 };
 
+struct LimitLinearJoint {
+  size_t referenceJointIndex;
+  size_t referenceJointParameter;
+  size_t targetJointIndex;
+  size_t targetJointParameter;
+  float scale;
+  float offset;
+
+  float rangeMin;
+  float rangeMax;
+};
+
 struct LimitEllipsoid {
   alignas(32) Affine3f ellipsoid;
   alignas(32) Affine3f ellipsoidInv;
@@ -71,6 +91,7 @@ union LimitData {
   LimitMinMax minMax;
   LimitMinMaxJoint minMaxJoint;
   LimitLinear linear;
+  LimitLinearJoint linearJoint;
   LimitEllipsoid ellipsoid;
   LimitHalfPlane halfPlane;
   unsigned char rawData[512];
@@ -107,6 +128,7 @@ ParameterLimits getPoseConstraintParameterLimits(
     float weight = 1.0f);
 
 bool isInRange(const LimitLinear& limit, float value);
+bool isInRange(const LimitLinearJoint& limit, float value);
 
 MOMENTUM_DEFINE_POINTERS(ParameterLimits)
 } // namespace momentum

--- a/momentum/character/parameter_transform.cpp
+++ b/momentum/character/parameter_transform.cpp
@@ -343,7 +343,6 @@ std::tuple<ParameterTransformT<T>, ParameterLimits> subsetParameterTransform(
       }
 
       case MinMaxJoint: {
-        //                auto& data = *((LimitMinMaxJoint*)limitNew.data);
         break;
       }
 
@@ -354,6 +353,10 @@ std::tuple<ParameterTransformT<T>, ParameterLimits> subsetParameterTransform(
         if (data.referenceIndex == kInvalidIndex || data.targetIndex == kInvalidIndex) {
           continue;
         }
+        break;
+      }
+
+      case LinearJoint: {
         break;
       }
 

--- a/momentum/character_solver/limit_error_function.cpp
+++ b/momentum/character_solver/limit_error_function.cpp
@@ -239,10 +239,10 @@ double LimitErrorFunctionT<T>::getGradient(
           error += residual * residual * limit.weight * tWeight;
 
           if (this->enabledParameters_.test(data.targetIndex)) {
-            gradient[data.targetIndex] += T(2) * residual * data.scale * tWeight;
+            gradient[data.targetIndex] += T(2) * residual * data.scale * limit.weight * tWeight;
           }
           if (this->enabledParameters_.test(data.referenceIndex)) {
-            gradient[data.referenceIndex] -= T(2) * residual * tWeight;
+            gradient[data.referenceIndex] -= T(2) * residual * limit.weight * tWeight;
           }
         }
         break;

--- a/momentum/io/gltf/utils/json_utils.cpp
+++ b/momentum/io/gltf/utils/json_utils.cpp
@@ -209,6 +209,28 @@ void parameterLimitsToJson(const Character& character, nlohmann::json& j) {
         li["targetParameter"] = character.parameterTransform.name[lim.data.linear.targetIndex];
         li["scale"] = lim.data.linear.scale;
         li["offset"] = lim.data.linear.offset;
+        if (lim.data.linear.rangeMin != -std::numeric_limits<float>::max()) {
+          li["rangeMin"] = lim.data.linear.rangeMin;
+        }
+        if (lim.data.linear.rangeMax != std::numeric_limits<float>::max()) {
+          li["rangeMax"] = lim.data.linear.rangeMax;
+        }
+        break;
+      case LinearJoint:
+        li["type"] = "linear_joint";
+        li["referenceJoint"] =
+            character.skeleton.joints.at(lim.data.linearJoint.referenceJointIndex).name;
+        li["referenceJointParameter"] = lim.data.linearJoint.referenceJointParameter;
+        li["targetJoint"] = character.skeleton.joints[lim.data.linearJoint.targetJointIndex].name;
+        li["targetJointParameter"] = lim.data.linearJoint.targetJointParameter;
+        li["scale"] = lim.data.linearJoint.scale;
+        li["offset"] = lim.data.linearJoint.offset;
+        if (lim.data.linearJoint.rangeMin != -std::numeric_limits<float>::max()) {
+          li["rangeMin"] = lim.data.linearJoint.rangeMin;
+        }
+        if (lim.data.linearJoint.rangeMax != std::numeric_limits<float>::max()) {
+          li["rangeMax"] = lim.data.linearJoint.rangeMax;
+        }
         break;
       case HalfPlane:
         li["type"] = "half_plane";
@@ -286,6 +308,20 @@ ParameterLimits parameterLimitsFromJson(const Character& character, const nlohma
           character.parameterTransform.getParameterIdByName(element.value("targetParameter", ""));
       l.data.linear.scale = element["scale"];
       l.data.linear.offset = element["offset"];
+      l.data.linear.rangeMin = element.value("rangeMin", -std::numeric_limits<float>::max());
+      l.data.linear.rangeMax = element.value("rangeMax", std::numeric_limits<float>::max());
+    } else if (type == "linear_joint") {
+      l.type = LinearJoint;
+      l.data.linearJoint.referenceJointIndex =
+          character.skeleton.getJointIdByName(element.value("referenceJoint", ""));
+      l.data.linearJoint.targetJointIndex =
+          character.skeleton.getJointIdByName(element.value("targetJoint", ""));
+      l.data.linearJoint.referenceJointParameter = element["referenceJointParameter"].get<size_t>();
+      l.data.linearJoint.targetJointParameter = element["targetJointParameter"].get<size_t>();
+      l.data.linearJoint.scale = element["scale"];
+      l.data.linearJoint.offset = element["offset"];
+      l.data.linearJoint.rangeMin = element.value("rangeMin", -std::numeric_limits<float>::max());
+      l.data.linearJoint.rangeMax = element.value("rangeMax", std::numeric_limits<float>::max());
     } else if (type == "half_plane") {
       l.type = HalfPlane;
       l.data.halfPlane.param1 =

--- a/momentum/test/character_solver/error_functions_test.cpp
+++ b/momentum/test/character_solver/error_functions_test.cpp
@@ -106,7 +106,7 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, LimitError_GradientsAndJacobians) {
     SCOPED_TRACE("Limit LinearTest");
     ParameterLimit limit;
     limit.type = Linear;
-    limit.weight = 1.0;
+    limit.weight = 1.5;
     limit.data.linear.referenceIndex = 0;
     limit.data.linear.targetIndex = 5;
     limit.data.linear.scale = 0.25;
@@ -134,7 +134,7 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, LimitError_GradientsAndJacobians) {
     limit.type = LimitType::Linear;
     limit.data.linear.referenceIndex = 0;
     limit.data.linear.targetIndex = 5;
-    limit.weight = 1.0f;
+    limit.weight = 0.5f;
 
     {
       ParameterLimit cur = limit;

--- a/momentum/test/io/io_parameter_limits_test.cpp
+++ b/momentum/test/io/io_parameter_limits_test.cpp
@@ -157,6 +157,58 @@ Character createCharacterWithLimits() {
   }
 
   {
+    // Linear joint limit affecting joint parameter:
+    ParameterLimit limit;
+    limit.type = LimitType::LinearJoint;
+    limit.weight = 2.5;
+    limit.data.linearJoint.referenceJointIndex = 2;
+    limit.data.linearJoint.referenceJointParameter = 3;
+    limit.data.linearJoint.targetJointIndex = 1;
+    limit.data.linearJoint.targetJointParameter = 0;
+
+    {
+      ParameterLimit cur = limit;
+      cur.data.linearJoint.scale = 1.0f;
+      cur.data.linearJoint.offset = 0.0f;
+      cur.data.linearJoint.rangeMin = -std::numeric_limits<float>::max();
+      cur.data.linearJoint.rangeMax = 0;
+      limits.push_back(cur);
+    }
+
+    {
+      ParameterLimit cur = limit;
+      cur.data.linearJoint.scale = -1.0f;
+      cur.data.linearJoint.offset = 4.0f;
+      cur.data.linearJoint.rangeMin = 0.0f;
+      cur.data.linearJoint.rangeMax = 2.0f;
+      limits.push_back(cur);
+    }
+
+    {
+      ParameterLimit cur = limit;
+      cur.data.linearJoint.scale = 1.0f;
+      cur.data.linearJoint.offset = -2.0f;
+      cur.data.linearJoint.rangeMin = 2.0f;
+      cur.data.linearJoint.rangeMax = std::numeric_limits<float>::max();
+      limits.push_back(cur);
+    }
+  }
+
+  {
+    // Linear joint limit affecting joint parameter:
+    ParameterLimit limit;
+    limit.type = LimitType::LinearJoint;
+    limit.weight = 2.5;
+    limit.data.linearJoint.referenceJointIndex = 2;
+    limit.data.linearJoint.referenceJointParameter = 3;
+    limit.data.linearJoint.targetJointIndex = 1;
+    limit.data.linearJoint.targetJointParameter = 0;
+    limit.data.linearJoint.scale = 1.2f;
+    limit.data.linearJoint.offset = 3.0f;
+    limits.push_back(limit);
+  }
+
+  {
     ParameterLimit limit;
     limit.type = LimitType::HalfPlane;
     limit.weight = 3.5;
@@ -207,6 +259,26 @@ void validateParameterLimitsSame(const ParameterLimits& limits1, const Parameter
           EXPECT_NEAR(l1.data.linear.rangeMax, l2.data.linear.rangeMax, 1e-4f);
         }
         break;
+      case LimitType::LinearJoint:
+        EXPECT_NEAR(l1.data.linearJoint.offset, l2.data.linearJoint.offset, 1e-4f);
+        EXPECT_NEAR(l1.data.linearJoint.scale, l2.data.linearJoint.scale, 1e-4f);
+        EXPECT_EQ(l1.data.linearJoint.targetJointIndex, l2.data.linearJoint.targetJointIndex);
+        EXPECT_EQ(l1.data.linearJoint.referenceJointIndex, l2.data.linearJoint.referenceJointIndex);
+        EXPECT_EQ(
+            l1.data.linearJoint.targetJointParameter, l2.data.linearJoint.targetJointParameter);
+        EXPECT_EQ(
+            l1.data.linearJoint.referenceJointParameter,
+            l2.data.linearJoint.referenceJointParameter);
+
+        if (l1.data.linearJoint.rangeMin == 0.0f && l1.data.linearJoint.rangeMax == 0.0f) {
+          EXPECT_EQ(l2.data.linearJoint.rangeMin, -std::numeric_limits<float>::max());
+          EXPECT_EQ(l2.data.linearJoint.rangeMax, std::numeric_limits<float>::max());
+        } else {
+          EXPECT_NEAR(l1.data.linearJoint.rangeMin, l2.data.linearJoint.rangeMin, 1e-4f);
+          EXPECT_NEAR(l1.data.linearJoint.rangeMax, l2.data.linearJoint.rangeMax, 1e-4f);
+        }
+        break;
+
       case LimitType::Ellipsoid:
         EXPECT_LE(
             (l1.data.ellipsoid.ellipsoid.matrix() - l2.data.ellipsoid.ellipsoid.matrix())


### PR DESCRIPTION
Summary: We want to be able to apply linear constraints on joint parameters, to get around issues with joints that have redundant model parameters.

Reviewed By: jeongseok-meta

Differential Revision: D66852452


