### PR TITLE
Enable character_test_helpers even when MOMENTUM_BUILD_TESTING=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,15 @@ mt_library(
 )
 
 mt_library(
+  NAME character_test_helpers
+  HEADERS_VARS character_test_helpers_public_headers
+  SOURCES_VARS character_test_helpers_sources
+  PUBLIC_LINK_LIBRARIES
+    character
+  EXCLUDE_FROM_INSTALL
+)
+
+mt_library(
   NAME solver
   HEADERS_VARS solver_public_headers
   SOURCES_VARS solver_sources
@@ -472,15 +481,6 @@ if(MOMENTUM_BUILD_TESTING)
       GTest::gtest
     PRIVATE_LINK_LIBRARIES
       Boost::boost
-    EXCLUDE_FROM_INSTALL
-  )
-
-  mt_library(
-    NAME character_test_helpers
-    HEADERS_VARS character_test_helpers_public_headers
-    SOURCES_VARS character_test_helpers_sources
-    PUBLIC_LINK_LIBRARIES
-      character
     EXCLUDE_FROM_INSTALL
   )
 


### PR DESCRIPTION
## Summary

The `character_test_helpers` target is required even when `MOMENTUM_BUILD_TESTING=OFF`, as it is necessary for building pymomentum regardless. This requirement can eliminate the need for a patch in the conda package: https://github.com/conda-forge/momentum-feedstock/blob/e96f4477c037a11acd2401cc3b855c81772cd91f/recipe/001-character-test-helpers.patch

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

CI
