### PR TITLE
Fix for bugs in parameter limit parsing.

### DIFF
--- a/momentum/io/skeleton/parameter_limits_io.cpp
+++ b/momentum/io/skeleton/parameter_limits_io.cpp
@@ -442,7 +442,7 @@ void parseLinearJoint(const std::string& parameterName, ParameterLimits& pl, Tok
   ParameterLimit p;
   p.weight = 1.0f;
   p.type = LinearJoint;
-  std::tie(p.data.linear.referenceIndex, p.data.linear.targetIndex) =
+  std::tie(p.data.linearJoint.referenceJointIndex, p.data.linearJoint.referenceJointParameter) =
       tokenizer.jointParameterIndexFromName(parameterName);
 
   // "<model parameter name> [<segment1_scale>, <segment1_offset>, segment1_rangeEnd>]
@@ -467,7 +467,7 @@ void parseLinearJoint(const std::string& parameterName, ParameterLimits& pl, Tok
 
   const auto sizeBefore = pl.size();
 
-  auto evalFunction = [](const LimitLinear& limit, float value) -> float {
+  auto evalFunction = [](const LimitLinearJoint& limit, float value) -> float {
     return limit.scale * value - limit.offset;
   };
 
@@ -504,8 +504,8 @@ void parseLinearJoint(const std::string& parameterName, ParameterLimits& pl, Tok
     if (pl.size() > sizeBefore) {
       const auto& pPrev = pl.back();
       MT_CHECK(pPrev.type == pCur.type);
-      const auto valuePrev = evalFunction(pPrev.data.linear, prevRangeMax);
-      const auto valueCur = evalFunction(pCur.data.linear, prevRangeMax);
+      const auto valuePrev = evalFunction(pPrev.data.linearJoint, prevRangeMax);
+      const auto valueCur = evalFunction(pCur.data.linearJoint, prevRangeMax);
 
       MT_THROW_IF(
           std::abs(valuePrev - valueCur) > 1e-3f,

--- a/momentum/test/io/io_parameter_limits_test.cpp
+++ b/momentum/test/io/io_parameter_limits_test.cpp
@@ -178,7 +178,7 @@ Character createCharacterWithLimits() {
     {
       ParameterLimit cur = limit;
       cur.data.linearJoint.scale = -1.0f;
-      cur.data.linearJoint.offset = 4.0f;
+      cur.data.linearJoint.offset = 0.0f;
       cur.data.linearJoint.rangeMin = 0.0f;
       cur.data.linearJoint.rangeMax = 2.0f;
       limits.push_back(cur);
@@ -187,7 +187,7 @@ Character createCharacterWithLimits() {
     {
       ParameterLimit cur = limit;
       cur.data.linearJoint.scale = 1.0f;
-      cur.data.linearJoint.offset = -2.0f;
+      cur.data.linearJoint.offset = 4.0f;
       cur.data.linearJoint.rangeMin = 2.0f;
       cur.data.linearJoint.rangeMax = std::numeric_limits<float>::max();
       limits.push_back(cur);


### PR DESCRIPTION
Summary:
There were actually two bugs:
1. We were parsing the reference joint index and parameter index into p.data.LINEAR.referenceIndex/targetIndex.  This is a pretty clear bug but those two fields just happen to be in the same place as the refJoint/refParam fields in data.linearJoint and so weren't causing a test failure.  
2. We weren't checking the right fields for the continuity test, meaning it wasn't triggering failures on discontinuous piecewise linear limits.  After I fixed this I got some errors in the test which have now been fixed.

Reviewed By: hzsydy

Differential Revision: D67112360


