### PR TITLE
Use "linear" instead of "linearJoint".

### DIFF
--- a/momentum/io/skeleton/parameter_limits_io.cpp
+++ b/momentum/io/skeleton/parameter_limits_io.cpp
@@ -645,9 +645,11 @@ ParameterLimits parseParameterLimits(
     } else if (type == "minmax_passive") {
       parseMinmaxPassive(parameterName, pl, tokenizer);
     } else if (type == "linear") {
-      parseLinear(parameterName, pl, tokenizer);
-    } else if (type == "linearJoint") {
-      parseLinearJoint(parameterName, pl, tokenizer);
+      if (parameterName.find('.') == std::string::npos) {
+        parseLinear(parameterName, pl, tokenizer);
+      } else {
+        parseLinearJoint(parameterName, pl, tokenizer);
+      }
     } else if (type == "halfplane") {
       parseHalfPlane(parameterName, pl, tokenizer);
     } else if (type == "ellipsoid") {
@@ -740,7 +742,7 @@ std::string writeParameterLimits(
       oss << jointParameterToName(
                  itr->data.linearJoint.referenceJointIndex,
                  itr->data.linearJoint.referenceJointParameter)
-          << " linearJoint "
+          << " linear "
           << jointParameterToName(
                  itr->data.linearJoint.targetJointIndex,
                  itr->data.linearJoint.targetJointParameter);

--- a/momentum/io/skeleton/parameter_limits_io.cpp
+++ b/momentum/io/skeleton/parameter_limits_io.cpp
@@ -442,7 +442,7 @@ void parseLinearJoint(const std::string& parameterName, ParameterLimits& pl, Tok
   ParameterLimit p;
   p.weight = 1.0f;
   p.type = LinearJoint;
-  std::tie(p.data.linear.referenceIndex, p.data.linear.targetIndex) =
+  std::tie(p.data.linearJoint.referenceJointIndex, p.data.linearJoint.referenceJointParameter) =
       tokenizer.jointParameterIndexFromName(parameterName);
 
   // "<model parameter name> [<segment1_scale>, <segment1_offset>, segment1_rangeEnd>]
@@ -467,7 +467,7 @@ void parseLinearJoint(const std::string& parameterName, ParameterLimits& pl, Tok
 
   const auto sizeBefore = pl.size();
 
-  auto evalFunction = [](const LimitLinear& limit, float value) -> float {
+  auto evalFunction = [](const LimitLinearJoint& limit, float value) -> float {
     return limit.scale * value - limit.offset;
   };
 
@@ -504,8 +504,8 @@ void parseLinearJoint(const std::string& parameterName, ParameterLimits& pl, Tok
     if (pl.size() > sizeBefore) {
       const auto& pPrev = pl.back();
       MT_CHECK(pPrev.type == pCur.type);
-      const auto valuePrev = evalFunction(pPrev.data.linear, prevRangeMax);
-      const auto valueCur = evalFunction(pCur.data.linear, prevRangeMax);
+      const auto valuePrev = evalFunction(pPrev.data.linearJoint, prevRangeMax);
+      const auto valueCur = evalFunction(pCur.data.linearJoint, prevRangeMax);
 
       MT_THROW_IF(
           std::abs(valuePrev - valueCur) > 1e-3f,

--- a/momentum/test/io/io_parameter_limits_test.cpp
+++ b/momentum/test/io/io_parameter_limits_test.cpp
@@ -178,7 +178,7 @@ Character createCharacterWithLimits() {
     {
       ParameterLimit cur = limit;
       cur.data.linearJoint.scale = -1.0f;
-      cur.data.linearJoint.offset = 4.0f;
+      cur.data.linearJoint.offset = 0.0f;
       cur.data.linearJoint.rangeMin = 0.0f;
       cur.data.linearJoint.rangeMax = 2.0f;
       limits.push_back(cur);
@@ -187,7 +187,7 @@ Character createCharacterWithLimits() {
     {
       ParameterLimit cur = limit;
       cur.data.linearJoint.scale = 1.0f;
-      cur.data.linearJoint.offset = -2.0f;
+      cur.data.linearJoint.offset = 4.0f;
       cur.data.linearJoint.rangeMin = 2.0f;
       cur.data.linearJoint.rangeMax = std::numeric_limits<float>::max();
       limits.push_back(cur);


### PR DESCRIPTION
Summary: For minmax limits, we don't require the user to say whether it's a minmaxJoint limit or a minmax limit on a model parameter.  We can use the same heuristic here and let the user say "linear" while using the actual parameter name to infer whether it's a joint or model param.

Differential Revision: D67112359


