### PR TITLE
Remove channel-priority override

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -315,21 +315,18 @@ platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 channels = ["conda-forge"]
 platforms = ["linux-64"]
 system-requirements = { cuda = "12.0" }
-channel-priority = "disabled"
 dependencies = { cuda-toolkit = "12.*", pytorch = { version = "2.5.*", build = "cuda126_py312*", channel = "conda-forge" } }
 
 [feature.py311-cuda126]
 channels = ["conda-forge"]
 platforms = ["linux-64"]
 system-requirements = { cuda = "12.0" }
-channel-priority = "disabled"
 dependencies = { cuda-toolkit = "12.*", pytorch = { version = "2.5.*", build = "cuda126_py311*", channel = "conda-forge" } }
 
 [feature.py310-cuda126]
 channels = ["conda-forge"]
 platforms = ["linux-64"]
 system-requirements = { cuda = "12.0" }
-channel-priority = "disabled"
 dependencies = { cuda-toolkit = "12.*", pytorch = { version = "2.5.*", build = "cuda126_py310*", channel = "conda-forge" } }
 
 #==============


### PR DESCRIPTION
## Summary

It's no longer needed as only one conda channel is used (i.e., conda-forge)

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

CI
