### PR TITLE
move annotations for expensive operations into library layer

### DIFF
--- a/momentum/character/linear_skinning.cpp
+++ b/momentum/character/linear_skinning.cpp
@@ -10,6 +10,7 @@
 #include "momentum/character/skeleton_state.h"
 #include "momentum/character/skin_weights.h"
 #include "momentum/common/checks.h"
+#include "momentum/common/profile.h"
 #include "momentum/math/mesh.h"
 
 #include <dispenso/parallel_for.h>
@@ -22,6 +23,8 @@ std::vector<Vector3<T>> applySSD(
     const SkinWeights& skin,
     typename DeduceSpanType<const Vector3<T>>::type points,
     const SkeletonStateT<T>& state) {
+  MT_PROFILE_FUNCTION();
+
   // some sanity checks
   MT_CHECK(
       state.jointState.size() == inverseBindPose.size(),
@@ -102,6 +105,8 @@ void applySSD(
     const MeshT<T>& mesh,
     const JointStateListT<T>& jointState,
     MeshT<T>& outputMesh) {
+  MT_PROFILE_FUNCTION();
+
   // some sanity checks
   MT_CHECK(
       jointState.size() >= inverseBindPose.size(),

--- a/momentum/character/parameter_transform.cpp
+++ b/momentum/character/parameter_transform.cpp
@@ -9,11 +9,10 @@
 
 #include "momentum/character/skeleton.h"
 #include "momentum/common/checks.h"
+#include "momentum/common/profile.h"
 #include "momentum/math/utility.h"
 
 #include <fmt/format.h>
-
-#include <type_traits>
 
 namespace momentum {
 
@@ -84,6 +83,7 @@ VectorX<bool> ParameterTransformT<T>::computeActiveJointParams(const ParameterSe
 // map model parameters to joint parameters using a linear transformation
 template <typename T>
 JointParametersT<T> ParameterTransformT<T>::apply(const ModelParametersT<T>& parameters) const {
+  MT_PROFILE_FUNCTION();
   MT_CHECK(
       parameters.size() == transform.cols(),
       "Size mismatch: The size of the parameters vector '{}' does not match the number of columns in the transform matrix '{}'.",
@@ -100,6 +100,7 @@ JointParametersT<T> ParameterTransformT<T>::apply(const ModelParametersT<T>& par
 // map model parameters to joint parameters using a linear transformation
 template <typename T>
 JointParametersT<T> ParameterTransformT<T>::apply(const CharacterParametersT<T>& parameters) const {
+  MT_PROFILE_FUNCTION();
   MT_CHECK(
       parameters.pose.size() == transform.cols(),
       "{} is not {}",

--- a/momentum/character/skeleton_state.cpp
+++ b/momentum/character/skeleton_state.cpp
@@ -9,6 +9,7 @@
 
 #include "momentum/character/skeleton.h"
 #include "momentum/common/checks.h"
+#include "momentum/common/profile.h"
 #include "momentum/math/types.h"
 
 namespace momentum {
@@ -41,6 +42,7 @@ SkeletonStateT<T>::SkeletonStateT(const SkeletonStateT<T2>& rhs)
 template <typename T>
 template <typename T2>
 void SkeletonStateT<T>::set(const SkeletonStateT<T2>& rhs) {
+  MT_PROFILE_FUNCTION();
   jointParameters = rhs.jointParameters.template cast<T>();
   jointState.resize(rhs.jointState.size());
   copy(rhs);
@@ -49,6 +51,7 @@ void SkeletonStateT<T>::set(const SkeletonStateT<T2>& rhs) {
 template <typename T>
 template <typename T2>
 void SkeletonStateT<T>::copy(const SkeletonStateT<T2>& rhs) {
+  MT_PROFILE_FUNCTION();
   for (size_t iJoint = 0; iJoint < jointState.size(); ++iJoint) {
     jointState[iJoint].set(rhs.jointState[iJoint]);
   }
@@ -59,6 +62,7 @@ void SkeletonStateT<T>::set(
     const JointParametersT<T>& parameters,
     const Skeleton& referenceSkeleton,
     bool computeDeriv) {
+  MT_PROFILE_FUNCTION();
   this->jointParameters = parameters;
   this->jointState.resize(referenceSkeleton.joints.size());
   set(referenceSkeleton, computeDeriv);
@@ -69,6 +73,7 @@ void SkeletonStateT<T>::set(
     JointParametersT<T>&& parameters,
     const Skeleton& referenceSkeleton,
     bool computeDeriv) {
+  MT_PROFILE_FUNCTION();
   this->jointParameters = std::move(parameters);
   this->jointState.resize(referenceSkeleton.joints.size());
   set(referenceSkeleton, computeDeriv);
@@ -76,6 +81,7 @@ void SkeletonStateT<T>::set(
 
 template <typename T>
 void SkeletonStateT<T>::set(const Skeleton& referenceSkeleton, bool computeDeriv) {
+  MT_PROFILE_FUNCTION();
   // get input joints
   const JointListT<T>& joints = ::momentum::cast<T>(referenceSkeleton.joints);
 

--- a/momentum/character/skeleton_utility.cpp
+++ b/momentum/character/skeleton_utility.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "momentum/character/skeleton_utility.h"
+#include "momentum/common/profile.h"
 
 namespace momentum {
 
@@ -14,6 +15,7 @@ ModelParameters extrapolateModelParameters(
     const ModelParameters& current,
     const float factor,
     const float maxDelta) {
+  MT_PROFILE_FUNCTION();
   // check if we have any reasonable data
   if (current.size() != previous.size()) {
     return current;
@@ -32,6 +34,7 @@ ModelParameters extrapolateModelParameters(
     const ParameterSet& activeParams,
     const float factor,
     const float maxDelta) {
+  MT_PROFILE_FUNCTION();
   if (current.size() != previous.size()) {
     return current;
   }


### PR DESCRIPTION
Summary: Used later in stack to avoid duplicate push/pop Annotations in downstream users code.

Reviewed By: jeongseok-meta

Differential Revision: D67427774


