### PR TITLE
Better rotation matrix identity check.

### DIFF
--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -488,7 +488,8 @@ void addSkeletonStatesToModel(
 
       auto localR = skeletonStates[i].jointState[j].localRotation().cast<float>();
       rotation[j][i] = {localR.x(), localR.y(), localR.z(), localR.w()};
-      if (!(localR.coeffs() - character.skeleton.joints[j].preRotation.coeffs()).isZero(1e-5f)) {
+      if (!(localR.toRotationMatrix() - character.skeleton.joints[j].preRotation.toRotationMatrix())
+               .isZero(1e-5f)) {
         useChannel[j][1] = true;
         foundAnyChannel = true;
       }

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -561,14 +561,12 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
 :parameter character: A Character to be saved to the output file.
 :parameter fps: Frequency in frames per second
 :parameter skel_states: Skeleton states [n_frames x n_joints x n_parameters_per_joint]
-:parameter joint_params: Joint parameters [n_joints x n_parameters_per_joint]
 :parameter markers: Additional marker (3d positions) data in [n_frames][n_markers]
       )",
           py::arg("path"),
           py::arg("character"),
           py::arg("fps"),
           py::arg("skel_states"),
-          py::arg("joint_params"),
           py::arg("markers") =
               std::optional<const std::vector<std::vector<momentum::Marker>>>{})
       .def_static(

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -332,8 +332,7 @@ std::shared_ptr<momentum::BlendShape> loadBlendShapeFromBytes(
   return std::make_shared<momentum::BlendShape>(std::move(result));
 }
 
-template <typename T>
-std::string formatDimensions(const py::array_t<T>& array) {
+std::string formatDimensions(const py::array& array) {
   std::ostringstream oss;
   oss << "[";
   for (size_t i = 0; i < array.ndim(); ++i) {

--- a/pymomentum/geometry/momentum_geometry.h
+++ b/pymomentum/geometry/momentum_geometry.h
@@ -212,4 +212,6 @@ pybind11::array_t<float> getBindPose(const momentum::Character& character);
 pybind11::array_t<float> getInverseBindPose(
     const momentum::Character& character);
 
+std::string formatDimensions(const pybind11::array& array);
+
 } // namespace pymomentum

--- a/pymomentum/geometry/momentum_io.h
+++ b/pymomentum/geometry/momentum_io.h
@@ -9,6 +9,7 @@
 
 #include <momentum/character/marker.h>
 #include <momentum/character/types.h>
+#include <pybind11/numpy.h>
 
 #include <optional>
 #include <string>
@@ -42,8 +43,7 @@ void saveGLTFCharacterToFileFromSkelStates(
     const std::string& path,
     const momentum::Character& character,
     const float fps,
-    const std::vector<RowMatrixf>& skel_states,
-    const std::vector<RowMatrixf>& joint_params,
+    const pybind11::array_t<float>& skel_states,
     std::optional<const std::vector<std::vector<momentum::Marker>>> markers);
 
 void saveFBXCharacterToFile(


### PR DESCRIPTION
Summary: Matching coeffs doesn't really do what you expect for quaternions, so let's compare the rotation matrices instead.

Reviewed By: yutingye, jeongseok-meta

Differential Revision: D67655916


