### PR TITLE
Replace depends_on with depends-on

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -81,26 +81,26 @@ config_dev = { cmd = """
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
     """, env = { MOMENTUM_BUILD_IO_FBX = "OFF", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
-build = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --target all", depends_on = [
+build = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --target all", depends-on = [
     "config",
 ] }
-build_dev = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/debug -j --target all", depends_on = [
+build_dev = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/debug -j --target all", depends-on = [
     "config_dev",
 ] }
-test = { cmd = "ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp/release --output-on-failure", depends_on = [
+test = { cmd = "ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp/release --output-on-failure", depends-on = [
     "build",
 ] }
-test_dev = { cmd = "ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp/debug --output-on-failure", depends_on = [
+test_dev = { cmd = "ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp/debug --output-on-failure", depends-on = [
     "build_dev",
 ] }
-hello_world = { cmd = "build/hello_world", depends_on = ["build"] }
-convert_model = { cmd = "build/convert_model", depends_on = ["build"] }
-c3d_viewer = { cmd = "build/c3d_viewer", depends_on = ["build"] }
-fbx_viewer = { cmd = "build/fbx_viewer", depends_on = ["build"] }
-glb_viewer = { cmd = "build/glb_viewer", depends_on = ["build"] }
-process_markers = { cmd = "build/process_markers_app", depends_on = ["build"] }
-refine_motion = { cmd = "build/refine_motion", depends_on = ["build"] }
-install = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --target install", depends_on = [
+hello_world = { cmd = "build/hello_world", depends-on = ["build"] }
+convert_model = { cmd = "build/convert_model", depends-on = ["build"] }
+c3d_viewer = { cmd = "build/c3d_viewer", depends-on = ["build"] }
+fbx_viewer = { cmd = "build/fbx_viewer", depends-on = ["build"] }
+glb_viewer = { cmd = "build/glb_viewer", depends-on = ["build"] }
+process_markers = { cmd = "build/process_markers_app", depends-on = ["build"] }
+refine_motion = { cmd = "build/refine_motion", depends-on = ["build"] }
+install = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --target install", depends-on = [
     "build",
 ] }
 
@@ -130,7 +130,7 @@ install_fbxsdk = { cmd = """
 """, outputs = [
     ".deps/fbxsdk/2020.3.7",
 ] }
-install_deps = { depends_on = ["install_fbxsdk"] }
+install_deps = { depends-on = ["install_fbxsdk"] }
 config = { cmd = """
     cmake \
         -S . \
@@ -146,7 +146,7 @@ config = { cmd = """
         -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
-    """, env = { FBXSDK_PATH = ".deps/fbxsdk", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" }, depends_on = [
+    """, env = { FBXSDK_PATH = ".deps/fbxsdk", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" }, depends-on = [
     "install_deps",
 ] }
 config_dev = { cmd = """
@@ -164,13 +164,13 @@ config_dev = { cmd = """
         -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
-    """, env = { FBXSDK_PATH = ".deps/fbxsdk", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" }, depends_on = [
+    """, env = { FBXSDK_PATH = ".deps/fbxsdk", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" }, depends-on = [
     "install_deps",
 ] }
 build_py = { cmd = "pip install . -vv", env = { FBXSDK_PATH = ".deps/fbxsdk", CMAKE_ARGS = """
     -DMOMENTUM_BUILD_IO_FBX=ON \
     -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD
-""", MOMENTUM_ENABLE_SIMD = "ON" }, depends_on = [
+""", MOMENTUM_ENABLE_SIMD = "ON" }, depends-on = [
     "install_deps",
 ] }
 test_py = { cmd = """
@@ -181,7 +181,7 @@ test_py = { cmd = """
         pymomentum/test/test_quaternion.py \
         pymomentum/test/test_skel_state.py \
         pymomentum/test/test_skeleton.py
-    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends_on = [
+    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",
 ] }
 
@@ -207,7 +207,7 @@ test_py = { cmd = """
         pymomentum/test/test_quaternion.py \
         pymomentum/test/test_skel_state.py \
         pymomentum/test/test_skeleton.py
-    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends_on = [
+    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",
 ] }
 
@@ -233,7 +233,7 @@ test_py = { cmd = """
         pymomentum/test/test_quaternion.py \
         pymomentum/test/test_skel_state.py \
         pymomentum/test/test_skeleton.py
-    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends_on = [
+    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",
 ] }
 
@@ -260,43 +260,43 @@ config = { cmd = """
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
     """, env = { MOMENTUM_BUILD_IO_FBX = "OFF", MOMENTUM_BUILD_PYMOMENTUM = "OFF", MOMENTUM_ENABLE_SIMD = "ON" } }
-open_vs = { cmd = "cmd /c start build\\$PIXI_ENVIRONMENT_NAME\\cpp\\momentum.sln", depends_on = [
+open_vs = { cmd = "cmd /c start build\\$PIXI_ENVIRONMENT_NAME\\cpp\\momentum.sln", depends-on = [
     "config",
 ] }
-build = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp -j --config Release", depends_on = [
+build = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp -j --config Release", depends-on = [
     "config",
 ] }
-build_dev = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp -j --config Debug", depends_on = [
+build_dev = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp -j --config Debug", depends-on = [
     "config",
 ] }
-test = { cmd = "ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp --output-on-failure --build-config Release", depends_on = [
+test = { cmd = "ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp --output-on-failure --build-config Release", depends-on = [
     "build",
 ] }
-test_dev = { cmd = "ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp --output-on-failure --build-config Debug", depends_on = [
+test_dev = { cmd = "ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp --output-on-failure --build-config Debug", depends-on = [
     "build_dev",
 ] }
-hello_world = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/hello_world.exe", depends_on = [
+hello_world = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/hello_world.exe", depends-on = [
     "build",
 ] }
-convert_model = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/convert_model.exe", depends_on = [
+convert_model = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/convert_model.exe", depends-on = [
     "build",
 ] }
-c3d_viewer = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/c3d_viewer.exe", depends_on = [
+c3d_viewer = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/c3d_viewer.exe", depends-on = [
     "build",
 ] }
-fbx_viewer = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/fbx_viewer.exe", depends_on = [
+fbx_viewer = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/fbx_viewer.exe", depends-on = [
     "build",
 ] }
-glb_viewer = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/glb_viewer.exe", depends_on = [
+glb_viewer = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/glb_viewer.exe", depends-on = [
     "build",
 ] }
-process_markers = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/process_markers_app.exe", depends_on = [
+process_markers = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/process_markers_app.exe", depends-on = [
     "build",
 ] }
-refine_motion = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/refine_motion.exe", depends_on = [
+refine_motion = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/refine_motion.exe", depends-on = [
     "build",
 ] }
-install = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp -j --target install --config Release", depends_on = [
+install = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp -j --target install --config Release", depends-on = [
     "build",
 ] }
 


### PR DESCRIPTION
## Summary

Pix has deprecated `depends_on` in favor of `depends-on` since version 0.40.0. Without this update, we encounter an error:

```bash
PS C:\Users\jeongseok\dev\momentum\main> pixi r config
Error: 
  × field 'depends_on' is deprecated, 'depends-on' has replaced it
     ╭─[pixi.toml:173:37]
 172 │     -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD
 173 │ """, MOMENTUM_ENABLE_SIMD = "ON" }, depends_on = [
     ·                                     ─────┬────
     ·                                          ╰── replace this with 'depends-on'
 174 │     "install_deps",
     ╰────
```

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

CI
