### PR TITLE
Retire custom grid

### DIFF
--- a/momentum/examples/c3d_viewer/c3d_viewer.cpp
+++ b/momentum/examples/c3d_viewer/c3d_viewer.cpp
@@ -55,8 +55,6 @@ int main(int argc, char* argv[]) {
     redirectLogsToRerun(rec);
 
     rec.log_static("world", ViewCoordinates::RUB); // Set an up-axis
-    // Create and draw ground plane
-    logGround(rec, "world/ground_plane", -200.f, 200.f, 15, 0.0);
 
     for (const auto& actor : sequences) {
       if (actor.frames.empty()) {

--- a/momentum/examples/fbx_viewer/fbx_viewer.cpp
+++ b/momentum/examples/fbx_viewer/fbx_viewer.cpp
@@ -69,8 +69,6 @@ int main(int argc, char* argv[]) {
     redirectLogsToRerun(rec);
 
     rec.log_static("world", ViewCoordinates::RUB); // Set an up-axis
-    // Create and draw ground plane
-    logGround(rec, "world/ground_plane", -200.f, 200, 15, 0.0);
 
     const auto [character, motions, fps] = loadOpenFbxCharacterWithMotion(
         options->fbxFile, true /*keepLocators*/, options->permissive);

--- a/momentum/examples/glb_viewer/glb_viewer.cpp
+++ b/momentum/examples/glb_viewer/glb_viewer.cpp
@@ -86,8 +86,6 @@ int main(int argc, char* argv[]) {
     redirectLogsToRerun(rec);
 
     rec.log_static("world", ViewCoordinates::RUB); // Set an up-axis
-    // Create and draw ground plane
-    logGround(rec, "world/ground_plane", -200.f, 200, 15, 0.0);
 
     const auto [character, motion, offsets, cFps] = loadCharacterWithMotion(options->glbFile);
     const size_t nFrames = motion.cols();

--- a/momentum/gui/rerun/logger.cpp
+++ b/momentum/gui/rerun/logger.cpp
@@ -44,29 +44,6 @@ rerun::HalfSize3D toRerunHalfSizes3D(const Eigen::MatrixBase<Derived>& vec3) {
   return rerun::HalfSize3D(vec3[0], vec3[1], vec3[2]);
 }
 
-// Creates a ground plane as line strips in momentum coordinate (Y-up)
-std::vector<std::vector<rerun::Position3D>>
-createGroundPlane(float from, float to, size_t n, float height) {
-  std::vector<std::vector<rerun::Position3D>> output;
-  for (float z : rerun::demo::linspace(from, to, n)) {
-    std::vector<rerun::Position3D> row;
-    for (float x : rerun::demo::linspace(from, to, n)) {
-      row.emplace_back(x, height, z);
-    }
-    output.emplace_back(row);
-  }
-
-  for (float x : rerun::demo::linspace(from, to, n)) {
-    std::vector<rerun::Position3D> col;
-    for (float z : rerun::demo::linspace(from, to, n)) {
-      col.emplace_back(x, height, z);
-    }
-    output.emplace_back(col);
-  }
-
-  return output;
-}
-
 } // namespace
 
 void logMesh(
@@ -413,18 +390,6 @@ void logCharacter(
     logCollisionGeometry(
         rec, charStreamName + "/collision_geometry", *collision, characterState.skeletonState);
   }
-}
-
-void logGround(
-    const rerun::RecordingStream& rec,
-    const std::string& streamName,
-    float from,
-    float to,
-    size_t n,
-    float height) {
-  auto points = createGroundPlane(from, to, n, height);
-  const rerun::Color grey(100, 100, 100);
-  rec.log_static(streamName, rerun::LineStrips3D(points).with_colors({grey}).with_radii({0.1f}));
 }
 
 } // namespace momentum

--- a/momentum/gui/rerun/logger.h
+++ b/momentum/gui/rerun/logger.h
@@ -100,13 +100,4 @@ void logJointParamNames(
     const std::string& posePrefix,
     gsl::span<const std::string> names);
 
-/// Logs to draw a plane as a grid.
-void logGround(
-    const rerun::RecordingStream& rec,
-    const std::string& streamName,
-    float from,
-    float to,
-    size_t n,
-    float height = 0);
-
 } // namespace momentum


### PR DESCRIPTION
Summary: Now that the grid is supported by the Rerun viewer, we no longer need to maintain our own grid logging, which was a temporary solution.

Reviewed By: juliencbmeta

Differential Revision: D69209651


