### PR TITLE
Add initial URDF parser

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -408,6 +408,21 @@ io_gltf_test_sources = [
     "test/io/io_gltf_test.cpp",
 ]
 
+io_urdf_public_headers = [
+    "io/urdf/urdf_io.h",
+]
+
+io_urdf_private_headers = [
+]
+
+io_urdf_sources = [
+    "io/urdf/urdf_io.cpp",
+]
+
+io_urdf_test_sources = [
+    "test/io/io_urdf_test.cpp",
+]
+
 io_motion_public_headers = [
     "io/motion/joint_params_binary_io.h",
     "io/motion/mmo_io.h",
@@ -571,6 +586,10 @@ glb_viewer_sources = [
 
 fbx_viewer_sources = [
     "examples/fbx_viewer/fbx_viewer.cpp",
+]
+
+urdf_viewer_sources = [
+    "examples/urdf_viewer/urdf_viewer.cpp",
 ]
 
 c3d_viewer_sources = [

--- a/momentum/character/skeleton.cpp
+++ b/momentum/character/skeleton.cpp
@@ -22,6 +22,53 @@ SkeletonT<T>::SkeletonT(JointList joints_in) : joints(std::move(joints_in)) {
 }
 
 template <typename T>
+size_t SkeletonT<T>::getJointIdByName(const std::string_view name) const {
+  for (size_t i = 0; i < joints.size(); i++) {
+    if (joints[i].name == name) {
+      return i;
+    }
+  }
+  return kInvalidIndex;
+}
+
+template <typename T>
+std::vector<std::string> SkeletonT<T>::getJointNames() const {
+  std::vector<std::string> result;
+  result.reserve(joints.size());
+  for (const auto& j : joints) {
+    result.emplace_back(j.name);
+  }
+  return result;
+}
+
+template <typename T>
+std::vector<size_t> SkeletonT<T>::getChildrenJoints(const size_t jointId, const bool recursive)
+    const {
+  MT_THROW_IF_T(
+      jointId >= joints.size(),
+      std::out_of_range,
+      "Out of bounds getChildrenJoints query. Requested index: {}. Number of joints: {}",
+      jointId,
+      joints.size());
+
+  std::vector<size_t> childrenJoints;
+  std::vector<int> jointDistance(joints.size(), -1);
+  jointDistance[jointId] = 0;
+
+  // traversal assuming parentJoint < childJoint
+  for (size_t jointIter = jointId + 1; jointIter < joints.size(); ++jointIter) {
+    const auto jointParent = joints[jointIter].parent;
+    const int distParent = (jointParent == kInvalidIndex) ? -1 : jointDistance[jointParent];
+    if ((recursive && distParent >= 0) || (!recursive && distParent == 0)) {
+      jointDistance[jointIter] = distParent + 1;
+      childrenJoints.push_back(jointIter);
+    }
+  }
+
+  return childrenJoints;
+}
+
+template <typename T>
 bool SkeletonT<T>::isAncestor(size_t jointId, size_t ancestorJointId) const {
   MT_CHECK(jointId < joints.size(), "{} vs {}", jointId, joints.size());
   MT_CHECK(ancestorJointId < joints.size(), "{} vs {}", ancestorJointId, joints.size());

--- a/momentum/character/skeleton.h
+++ b/momentum/character/skeleton.h
@@ -7,13 +7,13 @@
 
 #pragma once
 
-#include <string>
-#include <string_view>
-
 #include <momentum/character/joint.h>
 #include <momentum/character/parameter_transform.h>
 #include <momentum/character/types.h>
 #include <momentum/common/exception.h>
+
+#include <string>
+#include <string_view>
 
 namespace momentum {
 
@@ -27,49 +27,13 @@ struct SkeletonT {
   SkeletonT() = default;
 
   /// Look up the index of a joint from its name.
-  [[nodiscard]] size_t getJointIdByName(const std::string_view name) const {
-    for (size_t i = 0; i < joints.size(); i++)
-      if (joints[i].name == name)
-        return i;
-    return kInvalidIndex;
-  }
+  [[nodiscard]] size_t getJointIdByName(std::string_view name) const;
 
   /// Get the names of all the joints in this skeleton.
-  [[nodiscard]] std::vector<std::string> getJointNames() const {
-    std::vector<std::string> result;
-    result.reserve(joints.size());
-    for (const auto& j : joints)
-      result.emplace_back(j.name);
-    return result;
-  }
+  [[nodiscard]] std::vector<std::string> getJointNames() const;
 
   /// Get the list of indices of the direct children of a joint or all its descendants.
-  [[nodiscard]] std::vector<size_t> getChildrenJoints(
-      const size_t jointId,
-      const bool recursive = true) const {
-    MT_THROW_IF_T(
-        jointId >= joints.size(),
-        std::out_of_range,
-        "Out of bounds getChildrenJoints query. Requested index: {}. Number of joints: {}",
-        jointId,
-        joints.size());
-
-    std::vector<size_t> childrenJoints;
-    std::vector<int> jointDistance(joints.size(), -1);
-    jointDistance[jointId] = 0;
-
-    // traversal assuming parentJoint < childJoint
-    for (size_t jointIter = jointId + 1; jointIter < joints.size(); ++jointIter) {
-      const auto jointParent = joints[jointIter].parent;
-      const int distParent = (jointParent == kInvalidIndex) ? -1 : jointDistance[jointParent];
-      if ((recursive && distParent >= 0) || (!recursive && distParent == 0)) {
-        jointDistance[jointIter] = distParent + 1;
-        childrenJoints.push_back(jointIter);
-      }
-    }
-
-    return childrenJoints;
-  }
+  [[nodiscard]] std::vector<size_t> getChildrenJoints(size_t jointId, bool recursive = true) const;
 
   /// Check whether the two input joints lie on the same branch of the hierarchy.
   /// Returns true if ancestorJointId is an ancestor of jointId; that is,

--- a/momentum/examples/urdf_viewer/urdf_viewer.cpp
+++ b/momentum/examples/urdf_viewer/urdf_viewer.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <momentum/character/character.h>
+#include <momentum/character/character_state.h>
+#include <momentum/common/filesystem.h>
+#include <momentum/common/log.h>
+#include <momentum/gui/rerun/logger.h>
+#include <momentum/gui/rerun/logging_redirect.h>
+#include <momentum/io/urdf/urdf_io.h>
+
+#include <CLI/CLI.hpp>
+#include <rerun.hpp>
+
+#include <string>
+
+using namespace rerun;
+using namespace momentum;
+
+namespace {
+
+struct Options {
+  std::string urdfFile;
+  LogLevel logLevel = LogLevel::Info;
+  std::string title;
+  bool logJoints = false;
+};
+
+std::shared_ptr<Options> setupOptions(CLI::App& app) {
+  auto opt = std::make_shared<Options>();
+  app.add_option("--title", opt->title, "Title in viewer (default to be filename)");
+  app.add_option("-i,--input", opt->urdfFile, "Path to the URDF file")
+      ->required()
+      ->check(CLI::ExistingFile);
+  app.add_option("-l,--loglevel", opt->logLevel, "Set the log level")
+      ->transform(CLI::CheckedTransformer(logLevelMap(), CLI::ignore_case))
+      ->default_val(opt->logLevel);
+  app.add_flag("--log-joints", opt->logJoints, "Log joint parameters (very slow)")
+      ->default_val(opt->logJoints);
+  return opt;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  try {
+    CLI::App app("URDF Viewer");
+    auto options = setupOptions(app);
+    CLI11_PARSE(app, argc, argv);
+
+    setLogLevel(options->logLevel);
+
+    // Extract the file name from the path
+    const filesystem::path filePath(options->urdfFile);
+    const std::string fileName = filePath.filename().string();
+    if (filePath.extension() != ".urdf") {
+      MT_LOGE("{} is not a supported format.", fileName);
+      return 0;
+    }
+
+    const auto character = loadUrdfCharacter(options->urdfFile);
+
+    const auto kNumModelParams = character.parameterTransform.numAllModelParameters();
+
+    // Generate a random motion
+    const auto kNumFrames = 100;
+    const auto motion = MatrixXf::Zero(kNumModelParams, kNumFrames);
+    const float fps = 30.0f;
+
+    const std::string title = options->title.empty() ? fileName : options->title;
+    const auto rec = RecordingStream(title);
+    rec.spawn().exit_on_failure();
+
+    redirectLogsToRerun(rec);
+
+    rec.log_static("world", ViewCoordinates::RUB); // Set an up-axis
+
+    CharacterState charState;
+    CharacterParameters charParams;
+
+    for (auto i = 0; i < kNumFrames; ++i) {
+      // log timeline
+      rec.set_time_sequence("frame_index", i);
+      rec.set_time_seconds("log_time", (float)i / fps);
+
+      charParams.pose = motion.col(i);
+      charState.set(
+          charParams,
+          character,
+          true /*updateMesh*/,
+          true /*updateCollision*/,
+          false /*applyLimits*/);
+
+      logCharacter(rec, "world/character", character, charState);
+    }
+  } catch (const std::exception& e) {
+    MT_LOGE("Exception thrown. Error: {}", e.what());
+    return EXIT_FAILURE;
+  } catch (...) {
+    MT_LOGE("Exception thrown. Unknown error.");
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/momentum/io/urdf/urdf_io.cpp
+++ b/momentum/io/urdf/urdf_io.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/io/urdf/urdf_io.h"
+
+#include <urdf_model/link.h>
+#include <urdf_model/pose.h>
+#include <urdf_parser/urdf_parser.h>
+
+namespace momentum {
+
+namespace {
+
+constexpr size_t kMtoCM = 100.0;
+
+template <typename S>
+Vector3<S> toMomentumVector3(const urdf::Vector3& urdfVector3) {
+  return Vector3<S>(urdfVector3.x, urdfVector3.y, urdfVector3.z);
+}
+
+template <typename S>
+Quaternion<S> toMomentumQuaternion(const urdf::Rotation& urdfRotation) {
+  return Quaternion<S>(urdfRotation.w, urdfRotation.x, urdfRotation.y, urdfRotation.z);
+}
+
+template <typename S>
+TransformT<S> toMomentumTransform(const urdf::Pose& urdfPose) {
+  return TransformT<S>(
+      toMomentumVector3<S>(urdfPose.position), toMomentumQuaternion<S>(urdfPose.rotation));
+}
+
+template <typename T>
+bool loadUrdfSkeletonRecursive(
+    SkeletonT<T>& skeleton,
+    size_t parentJointId,
+    const urdf::ModelInterface* urdfModel,
+    const urdf::Link* urdfLink) {
+  MT_THROW_IF(urdfLink == nullptr, "URDF link is null.");
+
+  auto* urdfJoint = urdfLink->parent_joint.get();
+  MT_THROW_IF(
+      parentJointId != kInvalidIndex && urdfJoint == nullptr,
+      "URDF parent joint is null for a non root link ({}).",
+      urdfLink->name);
+
+  auto& joints = skeleton.joints;
+
+  Joint joint;
+  joint.name = urdfLink->name; // Use link name or joint name?
+  joint.parent = parentJointId;
+
+  // Set joint offset
+  if (urdfJoint != nullptr) {
+    const urdf::Pose& urdfPose = urdfJoint->parent_to_joint_origin_transform;
+    joint.preRotation.setIdentity();
+    joint.preRotation = toMomentumQuaternion<float>(urdfPose.rotation);
+    joint.translationOffset = toMomentumVector3<float>(urdfPose.position) * kMtoCM;
+  } else {
+    joint.preRotation.setIdentity();
+    joint.translationOffset.setZero();
+  }
+
+  const size_t jointId = joints.size();
+  joints.push_back(joint);
+
+  for (const auto& childLink : urdfLink->child_links) {
+    if (!loadUrdfSkeletonRecursive(skeleton, jointId, urdfModel, childLink.get())) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+} // namespace
+
+template <typename T>
+SkeletonT<T> loadUrdfSkeleton(const filesystem::path& filepath) {
+  urdf::ModelInterfaceSharedPtr urdfModel;
+
+  try {
+    urdfModel = urdf::parseURDFFile(filepath.string());
+  } catch (const std::runtime_error& e) {
+    MT_THROW("Failed to parse URDF file from: {}. Error: {}", filepath.string(), e.what());
+  }
+
+  const urdf::Link* root = urdfModel->getRoot().get();
+  if (!root) {
+    MT_THROW("Failed to parse URDF file from: {}. No root link found.", filepath.string());
+  }
+
+  if (root->name == "world") {
+    // The URDF's specification documentation doesn't explicitly describe but the users uses "world"
+    // as a reserved name for a link. If an URDF file contains a link with "world" name, then the
+    // world link is regarded as a fixed body with no DOFs. Otherwise, a root link with a different
+    // name, then it's regarded as a free floating (i.e., 6 DOFs) body.
+
+    if (root->child_links.empty()) {
+      MT_THROW(
+          "Failed to parse URDF file from: {}. The world link should have at least one child link.",
+          filepath.string());
+    } else if (root->child_links.size() > 1) {
+      MT_THROW(
+          "Failed to parse URDF file from: {}. The world link should have only one child link.",
+          filepath.string());
+    }
+
+    root = root->child_links[0].get();
+  }
+
+  SkeletonT<T> skeleton;
+
+  if (!loadUrdfSkeletonRecursive(skeleton, kInvalidIndex, urdfModel.get(), root)) {
+    MT_THROW("Failed to parse URDF file from: {}.", filepath.string());
+  }
+
+  return skeleton;
+}
+
+template SkeletonT<float> loadUrdfSkeleton(const filesystem::path& filepath);
+template SkeletonT<double> loadUrdfSkeleton(const filesystem::path& filepath);
+
+template <typename T>
+CharacterT<T> loadUrdfCharacter(const filesystem::path& filepath) {
+  const SkeletonT<float> skeleton = loadUrdfSkeleton<float>(filepath);
+
+  // TODO: Parse parameter transform reflecting the URDF joint types
+  const auto parameterTransform = ParameterTransform::identity(skeleton.getJointNames());
+
+  // TODO: Parse joint limits
+  // TODO: Parse collision geometries
+
+  return CharacterT<T>(skeleton, parameterTransform);
+}
+
+template CharacterT<float> loadUrdfCharacter(const filesystem::path& filepath);
+template CharacterT<double> loadUrdfCharacter(const filesystem::path& filepath);
+
+} // namespace momentum

--- a/momentum/io/urdf/urdf_io.h
+++ b/momentum/io/urdf/urdf_io.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/character/character.h>
+#include <momentum/common/filesystem.h>
+#include <momentum/math/types.h>
+
+#include <gsl/span>
+
+namespace momentum {
+
+template <typename T = float>
+[[nodiscard]] SkeletonT<T> loadUrdfSkeleton(const filesystem::path& filepath);
+
+template <typename T = float>
+[[nodiscard]] CharacterT<T> loadUrdfCharacter(const filesystem::path& filepath);
+
+} // namespace momentum

--- a/momentum/test/io/io_urdf_test.cpp
+++ b/momentum/test/io/io_urdf_test.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/io/urdf/urdf_io.h"
+#include "momentum/test/character/character_helpers.h"
+#include "momentum/test/character/character_helpers_gtest.h"
+#include "momentum/test/io/io_helpers.h"
+
+#include <gtest/gtest.h>
+
+using namespace momentum;
+
+namespace {
+
+std::optional<filesystem::path> getTestFilePath(const std::string& filename) {
+  auto envVar = GetEnvVar("TEST_MOMENTUM_MODELS_PATH");
+  if (!envVar.has_value()) {
+    return std::nullopt;
+  }
+  return filesystem::path(envVar.value()) / filename;
+}
+
+TEST(IoUrdfTest, LoadSkeleton) {
+  auto urdfPath = getTestFilePath("character.urdf");
+  if (!urdfPath.has_value()) {
+    GTEST_SKIP() << "Environment variable 'TEST_MOMENTUM_MODELS_PATH' is not set.";
+    return;
+  }
+
+  auto skeleton = loadUrdfSkeleton(*urdfPath);
+  EXPECT_EQ(skeleton.joints.size(), 45);
+  EXPECT_EQ(skeleton.joints[0].name, "b_root");
+  EXPECT_EQ(skeleton.joints[0].parent, kInvalidIndex);
+  EXPECT_TRUE(skeleton.joints[0].preRotation.isApprox(Quaternionf::Identity()));
+  EXPECT_TRUE(skeleton.joints[0].translationOffset.isApprox(Vector3f::Zero()));
+}
+
+TEST(IoUrdfTest, LoadCharacter) {
+  auto urdfPath = getTestFilePath("character.urdf");
+  if (!urdfPath.has_value()) {
+    GTEST_SKIP() << "Environment variable 'TEST_MOMENTUM_MODELS_PATH' is not set.";
+    return;
+  }
+
+  const auto& character = loadUrdfCharacter(*urdfPath);
+  const auto& skeleton = character.skeleton;
+  EXPECT_EQ(skeleton.joints.size(), 45);
+  EXPECT_EQ(skeleton.joints[0].name, "b_root");
+  EXPECT_EQ(skeleton.joints[0].parent, kInvalidIndex);
+  EXPECT_TRUE(skeleton.joints[0].preRotation.isApprox(Quaternionf::Identity()));
+  EXPECT_TRUE(skeleton.joints[0].translationOffset.isApprox(Vector3f::Zero()));
+}
+
+} // namespace


### PR DESCRIPTION
Summary:
- Add initial URDF parser that currently only parse joint hierarchy and offset. Other properties such as joint limits, collision geometries will be addressed in a follow-up Diffs
- Add URDF viewer that currently shows a static "motion" just to verify if the character structure is parsed correct in visually
- Move implementations of `SkeletonT` from header to source for cleaner header

Differential Revision: D68995554
