### PR TITLE
Add binding for loadUrdfCharacter

### DIFF
--- a/momentum/io/urdf/urdf_io.h
+++ b/momentum/io/urdf/urdf_io.h
@@ -19,4 +19,8 @@ namespace momentum {
 template <typename T = float>
 [[nodiscard]] CharacterT<T> loadUrdfCharacter(const filesystem::path& filepath);
 
+/// Loads a character from a URDF file using the provided byte data.
+template <typename T = float>
+[[nodiscard]] CharacterT<T> loadUrdfCharacter(gsl::span<const std::byte> bytes);
+
 } // namespace momentum

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -158,6 +158,8 @@ PYBIND11_MODULE(geometry, m) {
   // - load_fbx_with_motion_from_bytes(fbx_bytes, permissive)
   // - load_gltf(path)
   // - load_gltf_with_motion(gltfFilename)
+  // - load_urdf(urdf_filename)
+  // - load_urdf_from_bytes(urdf_bytes)
   // - save_gltf(path, character, fps, motion, offsets, markers)
   // - save_gltf_from_skel_states(path, character, fps, skel_states,
   // joint_params, markers)
@@ -529,6 +531,26 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
 :parameter path: A .gltf file; e.g. character_s0.glb.
       )",
           py::arg("path"))
+      // loadURDFCharacterFromFile(urdfPath)
+      .def_static(
+          "load_urdf",
+          &loadURDFCharacterFromFile,
+          py::call_guard<py::gil_scoped_release>(),
+          R"(Load a character from a urdf file.
+
+:parameter urdf_filename: A .urdf file; e.g. character.urdf.
+      )",
+          py::arg("urdf_filename"))
+      // loadURDFCharacterFromBytes(urdfBytes)
+      .def_static(
+          "load_urdf_from_bytes",
+          &loadURDFCharacterFromBytes,
+          py::call_guard<py::gil_scoped_release>(),
+          R"(Load a character from urdf bytes.
+
+:parameter urdf_bytes: Bytes array containing the urdf definition.
+      )",
+          py::arg("urdf_bytes"))
       // saveGLTFCharacterToFile(filename, character)
       .def_static(
           "save_gltf",
@@ -622,7 +644,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
             return character.simplify(enabledParams);
           },
           R"(Simplifies the character by removing extra joints; this can help to speed up IK, but passing in a set of
-parameters rather than joints.  Does not modify the parameter transform.  This is the equivalent of calling 
+parameters rather than joints.  Does not modify the parameter transform.  This is the equivalent of calling
 ```character.simplify_skeleton(character.joints_from_parameters(enabled_params))```.
 
 :parameter enabled_parameters: Model parameters to be kept in the simplified model.  Defaults to including all parameters.

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -25,6 +25,7 @@
 #include <momentum/io/skeleton/locator_io.h>
 #include <momentum/io/skeleton/mppca_io.h>
 #include <momentum/io/skeleton/parameter_transform_io.h>
+#include <momentum/io/urdf/urdf_io.h>
 #include <momentum/math/mesh.h>
 
 #include <torch/csrc/jit/python/python_ivalue.h>
@@ -312,6 +313,15 @@ momentum::Character loadLocatorsFromBytes(
   std::copy(
       locators.begin(), locators.end(), std::back_inserter(result.locators));
   return result;
+}
+
+momentum::Character loadURDFCharacterFromFile(const std::string& urdfPath) {
+  return momentum::loadUrdfCharacter<float>(urdfPath);
+}
+
+momentum::Character loadURDFCharacterFromBytes(
+    const pybind11::bytes& urdfBytes) {
+  return momentum::loadUrdfCharacter<float>(toSpan<std::byte>(urdfBytes));
 }
 
 std::shared_ptr<const momentum::Mppca> loadPosePriorFromFile(

--- a/pymomentum/geometry/momentum_geometry.h
+++ b/pymomentum/geometry/momentum_geometry.h
@@ -78,6 +78,10 @@ momentum::Character loadConfigFromBytes(
     const momentum::Character& character,
     const pybind11::bytes& bytes);
 
+momentum::Character loadURDFCharacterFromFile(const std::string& urdfPath);
+momentum::Character loadURDFCharacterFromBytes(
+    const pybind11::bytes& urdfBytes);
+
 // Convert uniform noise to meaningful model parameters.
 // unifNoise: size: batchSize (optional) x #modelParameters, each entry
 //   range in [0, 1].
@@ -179,10 +183,10 @@ std::vector<int> bitsetToJointList(const std::vector<bool>& jointMask);
 /// @param[in] character A momentum character object with locators
 /// @param[in] names A vector of locator names
 /// @return A tuple of (locator_parents, locator_offsets)
-/// locator_parents has the same size as names vector and contains parent index
-/// of the locator if found otherwise -1. locator_offsets is a matrix of size
-/// (names.size(), 3) containing the offset of the locator wrt locators' parent
-/// joint
+/// locator_parents has the same size as names vector and contains parent
+/// index of the locator if found otherwise -1. locator_offsets is a matrix of
+/// size (names.size(), 3) containing the offset of the locator wrt locators'
+/// parent joint
 std::tuple<Eigen::VectorXi, RowMatrixf> getLocators(
     const momentum::Character& character,
     const std::vector<std::string>& names);


### PR DESCRIPTION
Summary:
Add Python bindings for `loadUrdfCharacter()` with two functions:
- `load_urdf()`: Load a character from a URDF file.
- `load_urdf_from_bytes()`: Load a character from URDF bytes

Differential Revision: D69280695
