### PR TITLE
Publish website with Python API docs

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -58,7 +58,7 @@ jobs:
         include:
           - pixi_env: "cpu"
           - pixi_env: "gpu"
-            cuda_version: "12.6.2"
+            cuda_version: "12.8.0"
     env:
       FULL_CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:
@@ -103,7 +103,7 @@ jobs:
       - name: Build PyMomentum
         run: |
           pixi run -e ${{ matrix.pixi_env }} test_py
-     
+
       - name: Build Python API Doc
         run: |
           MOMENTUM_BUILD_IO_FBX=ON \

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -2,9 +2,15 @@ name: Publish Website
 
 on:
   push:
-    branches: [ main ]
+    paths:
+      - "momentum/website/**"
+      - "pymomentum/**"
+      - ".github/workflows/publish_website.yml"
   pull_request:
-    branches: [ main ]
+    paths:
+      - "momentum/website/**"
+      - "pymomentum/**"
+      - ".github/workflows/publish_website.yml"
   workflow_dispatch:
 
 jobs:
@@ -12,16 +18,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # 0) Clean up disk
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
+      with:
+        root-reserve-mb: 32768
+        remove-dotnet: true
+        remove-android: true
+        remove-haskell: true
+        remove-codeql: true
+        remove-docker-images: true
+
+    # 1) Check out the repository
     - name: Checkout
       uses: actions/checkout@v4
 
+    # 2) Build Docusaurus site with C++ docs (using Doxygen)
     - uses: actions/setup-node@v4
       with:
           node-version: 18
           cache: yarn
           cache-dependency-path: ./momentum/website/yarn.lock
 
-    - name: Install dependencies
+    - name: Install Doxygen
       run: sudo apt-get install doxygen
 
     - name: Build the Website
@@ -30,10 +49,34 @@ jobs:
         yarn install --frozen-lockfile
         yarn run build
 
-    - name: Deploy
-      if: ${{ github.event_name == 'push' }}
+    # 3) Build Python API docs
+    - name: Set up pixi
+      uses: prefix-dev/setup-pixi@v0.8.1
+      with:
+        cache: true
+
+    - name: Build Python API Documentation
+      run: |
+        MOMENTUM_BUILD_IO_FBX=ON \
+          pixi run doc_py
+
+    # 4) Copy Python API Documentation to Docusaurus
+    - name: Copy Python API Documentation
+      run: |
+        cp -R build/python_api_doc momentum/website/build/python_api_doc
+
+    # 5) Upload the built website as an artifact
+    - name: Upload Built Website
+      uses: actions/upload-artifact@v4
+      with:
+        name: built-website
+        path: momentum/website/build
+
+    # 5) Deploy Docusaurus folder to GitHub Pages
+    - name: Deploy to GiHub Pages
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       uses: JamesIves/github-pages-deploy-action@releases/v4
       with:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: momentum/website/build # The folder the action should deploy.
+          BRANCH: gh-pages
+          FOLDER: momentum/website/build

--- a/momentum/website/docusaurus.config.js
+++ b/momentum/website/docusaurus.config.js
@@ -77,6 +77,11 @@ const {fbContent, fbInternalOnly} = require('docusaurus-plugin-internaldocs-fb/i
             label: 'C++ API',
           },
           {
+            href: 'pathname:///python_api_doc/index.html',
+            position: 'left',
+            label: 'Python API',
+          },
+          {
             href: 'https://github.com/facebookincubator/momentum',
             label: 'GitHub',
             position: 'right',

--- a/pixi.toml
+++ b/pixi.toml
@@ -212,10 +212,10 @@ test_py = { cmd = """
     "build_py",
 ] }
 install_py = { cmd = "pip install -e ." }
-doc_py = { cmd = "sphinx-build -a -E -b html pymomentum/doc build/html", depends-on = [
+doc_py = { cmd = "sphinx-build -a -E -b html pymomentum/doc build/python_api_doc", depends-on = [
     "install_py",
 ] }
-open_doc_py = { cmd = "open build/html/index.html", depends-on = ["doc_py"] }
+open_doc_py = { cmd = "open build/python_api_doc/index.html", depends-on = ["doc_py"] }
 
 #============
 # osx-64
@@ -243,10 +243,10 @@ test_py = { cmd = """
     "build_py",
 ] }
 install_py = { cmd = "pip install -e ." }
-doc_py = { cmd = "sphinx-build -a -E -b html pymomentum/doc build/html", depends-on = [
+doc_py = { cmd = "sphinx-build -a -E -b html pymomentum/doc build/python_api_doc", depends-on = [
     "install_py",
 ] }
-open_doc_py = { cmd = "open build/html/index.html", depends-on = ["doc_py"] }
+open_doc_py = { cmd = "open build/python_api_doc/index.html", depends-on = ["doc_py"] }
 
 #============
 # osx-arm64
@@ -274,10 +274,10 @@ test_py = { cmd = """
     "build_py",
 ] }
 install_py = { cmd = "pip install -e ." }
-doc_py = { cmd = "sphinx-build -a -E -b html pymomentum/doc build/html", depends-on = [
+doc_py = { cmd = "sphinx-build -a -E -b html pymomentum/doc build/python_api_doc", depends-on = [
     "install_py",
 ] }
-open_doc_py = { cmd = "open build/html/index.html", depends-on = ["doc_py"] }
+open_doc_py = { cmd = "open build/python_api_doc/index.html", depends-on = ["doc_py"] }
 
 #=========
 # win-64


### PR DESCRIPTION
## Summary

Now that the PyMomentum API documentation can be generated (by running `pixi run doc_py`), we publish it on our website alongside the existing C++ API documentation using GitHub Actions.

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

Published to the `gh-pages` branch for testing, and confirmed that the website is generated as expected:

The main page has "Python API" link:

![image](https://github.com/user-attachments/assets/9cd156a2-6090-4b3e-8744-cc951de486eb)

and it opens a new tab as:

![image](https://github.com/user-attachments/assets/a46a6a62-e758-4e9e-a60c-7647ab25eb45)
