### PR TITLE
Add tensor_ik and solver targets

### DIFF
--- a/cmake/mt_defs.cmake
+++ b/cmake/mt_defs.cmake
@@ -490,3 +490,63 @@ function(mt_python_binding)
     set_property(GLOBAL APPEND PROPERTY PYMOMENTUM_TARGETS_TO_INSTALL ${_ARG_NAME})
   endif()
 endfunction()
+
+function(mt_python_library)
+  set(prefix _ARG)
+  set(options
+    EXCLUDE_FROM_INSTALL
+  )
+  set(oneValueArgs
+    NAME
+  )
+  set(multiValueArgs
+    PYMOMENTUM_SOURCES_VARS
+  )
+  cmake_parse_arguments(
+    "${prefix}"
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
+
+  foreach(var ${_ARG_PYMOMENTUM_SOURCES_VARS})
+    mt_append_pymomentum_filelist("${var}" libs)
+  endforeach()
+
+  if(NOT ${_ARG_EXCLUDE_FROM_INSTALL})
+    set_property(GLOBAL APPEND PROPERTY PYMOMENTUM_PYTHON_LIBRARIES_TO_INSTALL ${libs})
+  endif()
+endfunction()
+
+function(mt_install_pymomentum)
+  set(prefix _ARG)
+  set(options
+  )
+  set(oneValueArgs
+    GIT_TAG
+  )
+  set(multiValueArgs
+  )
+  cmake_parse_arguments(
+    "${prefix}"
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
+
+  # Install C++ binding modules
+  get_property(pymomentum_targets_to_install GLOBAL PROPERTY PYMOMENTUM_TARGETS_TO_INSTALL)
+  install(
+    TARGETS ${pymomentum_targets_to_install}
+    DESTINATION pymomentum
+  )
+
+  # Install Python modules
+  get_property(pymomentum_python_libraries_to_install GLOBAL PROPERTY PYMOMENTUM_PYTHON_LIBRARIES_TO_INSTALL)
+  install(
+    FILES ${pymomentum_python_libraries_to_install}
+    DESTINATION pymomentum
+  )
+endfunction()

--- a/cmake/mt_defs.cmake
+++ b/cmake/mt_defs.cmake
@@ -433,6 +433,7 @@ function(mt_python_binding)
   )
   set(oneValueArgs
     NAME
+    MODULE_NAME
   )
   set(multiValueArgs
     HEADERS
@@ -485,6 +486,13 @@ function(mt_python_binding)
   target_compile_features(${_ARG_NAME} PRIVATE cxx_std_17)
   target_link_libraries(${_ARG_NAME} PRIVATE ${_ARG_LINK_LIBRARIES})
   target_compile_options(${_ARG_NAME} PRIVATE ${_ARG_COMPILE_OPTIONS})
+
+  if(NOT _ARG_MODULE_NAME)
+      set(_ARG_MODULE_NAME ${_ARG_NAME})
+  endif()
+  set_target_properties(${_ARG_NAME} PROPERTIES
+      OUTPUT_NAME "${_ARG_MODULE_NAME}"
+  )
 
   if(NOT ${_ARG_EXCLUDE_FROM_INSTALL})
     set_property(GLOBAL APPEND PROPERTY PYMOMENTUM_TARGETS_TO_INSTALL ${_ARG_NAME})

--- a/momentum/test/character_solver/error_functions_test.cpp
+++ b/momentum/test/character_solver/error_functions_test.cpp
@@ -1449,7 +1449,7 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, ProjectionError_GradientsAndJacobians) {
           ModelParametersT<T>::Zero(transform.numAllModelParameters()),
           skeleton,
           transform,
-          1e-7,
+          1e-6,
           1e-6,
           true,
           false); // jacobian test is inaccurate around the corner case
@@ -1466,7 +1466,7 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, ProjectionError_GradientsAndJacobians) {
           parameters,
           skeleton,
           transform,
-          Eps<T>(1e-1f, 1e-3),
+          Eps<T>(1e-1f, 5e-3),
           Eps<T>(1e-6f, 1e-7));
     }
   }

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -130,38 +130,6 @@ mt_python_binding(
 )
 
 mt_python_binding(
-  NAME quaternion
-  PYMOMENTUM_HEADERS_VARS quaternion_public_headers
-  PYMOMENTUM_SOURCES_VARS quaternion_sources
-  INCLUDE_DIRECTORIES
-    ${ATEN_INCLUDE_DIR}
-    ${TORCH_LIBRARIES}
-  LINK_LIBRARIES
-    tensor_momentum
-    ${ATEN_LIBRARIES}
-    ${TORCH_LIBRARIES}
-    ${torch_python}
-  COMPILE_OPTIONS
-    ${TORCH_CXX_FLAGS}
-)
-
-mt_python_binding(
-  NAME skel_state
-  PYMOMENTUM_HEADERS_VARS skel_state_public_headers
-  PYMOMENTUM_SOURCES_VARS skel_state_sources
-  INCLUDE_DIRECTORIES
-    ${ATEN_INCLUDE_DIR}
-    ${TORCH_LIBRARIES}
-  LINK_LIBRARIES
-    tensor_momentum
-    ${ATEN_LIBRARIES}
-    ${TORCH_LIBRARIES}
-    ${torch_python}
-  COMPILE_OPTIONS
-    ${TORCH_CXX_FLAGS}
-)
-
-mt_python_binding(
   NAME marker_tracking
   PYMOMENTUM_HEADERS_VARS marker_tracking_public_headers
   PYMOMENTUM_SOURCES_VARS marker_tracking_sources
@@ -172,6 +140,16 @@ mt_python_binding(
     math
     process_markers
   COMPILE_OPTIONS
+)
+
+mt_python_library(
+  NAME quaternion
+  PYMOMENTUM_SOURCES_VARS quaternion_sources
+)
+
+mt_python_library(
+  NAME skel_state
+  PYMOMENTUM_SOURCES_VARS skel_state_sources
 )
 
 #===============================================================================
@@ -193,5 +171,4 @@ endif()
 # Install
 #===============================================================================
 
-get_property(pymomentum_targets_to_install GLOBAL PROPERTY PYMOMENTUM_TARGETS_TO_INSTALL)
-install(TARGETS ${pymomentum_targets_to_install} DESTINATION pymomentum)
+mt_install_pymomentum()

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -83,7 +83,7 @@ mt_library(
   PUBLIC_INCLUDE_DIRECTORIES
     ${ATEN_INCLUDE_DIR}
   PRIVATE_INCLUDE_DIRECTORIES
-    ${TORCH_LIBRARIES}
+    ${TORCH_INCLUDE_DIRS}
   PUBLIC_LINK_LIBRARIES
     momentum
     ${ATEN_LIBRARIES}
@@ -91,8 +91,29 @@ mt_library(
   PRIVATE_LINK_LIBRARIES
     python_utility
     tensor_utility
-    axel
     Ceres::ceres
+    Dispenso::dispenso
+    Eigen3::Eigen
+    ${TORCH_LIBRARIES}
+    ${torch_python}
+  PUBLIC_COMPILE_OPTIONS
+    ${TORCH_CXX_FLAGS}
+  EXCLUDE_FROM_INSTALL
+)
+
+mt_library(
+  NAME tensor_ik
+  PYMOMENTUM_HEADERS_VARS tensor_ik_public_headers
+  PYMOMENTUM_SOURCES_VARS tensor_ik_sources
+  PUBLIC_INCLUDE_DIRECTORIES
+    ${ATEN_INCLUDE_DIR}
+  PRIVATE_INCLUDE_DIRECTORIES
+    ${TORCH_INCLUDE_DIRS}
+  PUBLIC_LINK_LIBRARIES
+    momentum
+    ${ATEN_LIBRARIES}
+  PRIVATE_LINK_LIBRARIES
+    tensor_utility
     Dispenso::dispenso
     Eigen3::Eigen
     ${TORCH_LIBRARIES}
@@ -108,7 +129,7 @@ mt_python_binding(
   PYMOMENTUM_SOURCES_VARS geometry_sources
   INCLUDE_DIRECTORIES
     ${ATEN_INCLUDE_DIR}
-    ${TORCH_LIBRARIES}
+    ${TORCH_INCLUDE_DIRS}
   LINK_LIBRARIES
     character
     character_test_helpers
@@ -120,6 +141,30 @@ mt_python_binding(
     io_skeleton
     io_urdf
     python_utility
+    tensor_momentum
+    tensor_utility
+    ${ATEN_LIBRARIES}
+    ${TORCH_LIBRARIES}
+    ${torch_python}
+  COMPILE_OPTIONS
+    ${TORCH_CXX_FLAGS}
+)
+
+mt_python_binding(
+  NAME pymomentum_solver
+  MODULE_NAME solver
+  PYMOMENTUM_HEADERS_VARS solver_public_headers
+  PYMOMENTUM_SOURCES_VARS solver_sources
+  INCLUDE_DIRECTORIES
+    ${ATEN_INCLUDE_DIR}
+    ${TORCH_INCLUDE_DIRS}
+  LINK_LIBRARIES
+    character_solver
+    math
+    skeleton
+    geometry
+    python_utility
+    tensor_ik
     tensor_momentum
     tensor_utility
     ${ATEN_LIBRARIES}
@@ -163,6 +208,12 @@ if(MOMENTUM_BUILD_TESTING)
   mt_test(
     NAME tensor_utility_test
     PYMOMENTUM_SOURCES_VARS tensor_utility_test_sources
+    LINK_LIBRARIES tensor_utility
+  )
+
+  mt_test(
+    NAME tensor_ik_test
+    PYMOMENTUM_SOURCES_VARS tensor_ik_test_sources
     LINK_LIBRARIES tensor_utility
   )
 endif()

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -50,6 +50,46 @@ tensor_momentum_sources = [
     "tensor_momentum/tensor_transforms.cpp",
 ]
 
+tensor_ik_public_headers = [
+    "tensor_ik/solver_options.h",
+    "tensor_ik/tensor_collision_error_function.h",
+    "tensor_ik/tensor_diff_pose_prior_error_function.h",
+    "tensor_ik/tensor_distance_error_function.h",
+    "tensor_ik/tensor_error_function_utility.h",
+    "tensor_ik/tensor_error_function.h",
+    "tensor_ik/tensor_gradient.h",
+    "tensor_ik/tensor_ik_utility.h",
+    "tensor_ik/tensor_ik.h",
+    "tensor_ik/tensor_limit_error_function.h",
+    "tensor_ik/tensor_marker_error_function.h",
+    "tensor_ik/tensor_motion_error_function.h",
+    "tensor_ik/tensor_pose_prior_error_function.h",
+    "tensor_ik/tensor_projection_error_function.h",
+    "tensor_ik/tensor_residual.h",
+    "tensor_ik/tensor_vertex_error_function.h",
+]
+
+tensor_ik_sources = [
+    "tensor_ik/tensor_collision_error_function.cpp",
+    "tensor_ik/tensor_diff_pose_prior_error_function.cpp",
+    "tensor_ik/tensor_distance_error_function.cpp",
+    "tensor_ik/tensor_error_function.cpp",
+    "tensor_ik/tensor_gradient.cpp",
+    "tensor_ik/tensor_ik_utility.cpp",
+    "tensor_ik/tensor_ik.cpp",
+    "tensor_ik/tensor_limit_error_function.cpp",
+    "tensor_ik/tensor_marker_error_function.cpp",
+    "tensor_ik/tensor_motion_error_function.cpp",
+    "tensor_ik/tensor_pose_prior_error_function.cpp",
+    "tensor_ik/tensor_projection_error_function.cpp",
+    "tensor_ik/tensor_residual.cpp",
+    "tensor_ik/tensor_vertex_error_function.cpp",
+]
+
+tensor_ik_test_sources = [
+    "cpp_test/tensor_ik_test.cpp",
+]
+
 geometry_public_headers = [
     "geometry/momentum_geometry.h",
     "geometry/momentum_io.h",
@@ -59,6 +99,15 @@ geometry_sources = [
     "geometry/geometry_pybind.cpp",
     "geometry/momentum_geometry.cpp",
     "geometry/momentum_io.cpp",
+]
+
+solver_public_headers = [
+    "solver/momentum_ik.h",
+]
+
+solver_sources = [
+    "solver/momentum_ik.cpp",
+    "solver/solver_pybind.cpp",
 ]
 
 quaternion_sources = [

--- a/pymomentum/solver/momentum_ik.cpp
+++ b/pymomentum/solver/momentum_ik.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/solver/momentum_ik.h"
 

--- a/pymomentum/solver/momentum_ik.h
+++ b/pymomentum/solver/momentum_ik.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/solver/solver_pybind.cpp
+++ b/pymomentum/solver/solver_pybind.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/solver/momentum_ik.h"
 #include "pymomentum/tensor_ik/solver_options.h"

--- a/pymomentum/tensor_ik/solver_options.h
+++ b/pymomentum/tensor_ik/solver_options.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_collision_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_collision_error_function.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_collision_error_function.h"
 

--- a/pymomentum/tensor_ik/tensor_collision_error_function.h
+++ b/pymomentum/tensor_ik/tensor_collision_error_function.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_diff_pose_prior_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_diff_pose_prior_error_function.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_diff_pose_prior_error_function.h"
 

--- a/pymomentum/tensor_ik/tensor_diff_pose_prior_error_function.h
+++ b/pymomentum/tensor_ik/tensor_diff_pose_prior_error_function.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_distance_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_distance_error_function.cpp
@@ -2,7 +2,6 @@
 
 #include "pymomentum/tensor_ik/tensor_distance_error_function.h"
 
-#include "pymomentum/nimble/tensor_camera/camera_utility.h"
 #include "pymomentum/tensor_ik/tensor_error_function_utility.h"
 
 #include <momentum/character/character.h>

--- a/pymomentum/tensor_ik/tensor_distance_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_distance_error_function.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_distance_error_function.h"
 

--- a/pymomentum/tensor_ik/tensor_distance_error_function.h
+++ b/pymomentum/tensor_ik/tensor_distance_error_function.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_error_function.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_error_function.h"
 

--- a/pymomentum/tensor_ik/tensor_error_function.h
+++ b/pymomentum/tensor_ik/tensor_error_function.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_error_function_utility.h
+++ b/pymomentum/tensor_ik/tensor_error_function_utility.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_gradient.cpp
+++ b/pymomentum/tensor_ik/tensor_gradient.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_gradient.h"
 

--- a/pymomentum/tensor_ik/tensor_gradient.h
+++ b/pymomentum/tensor_ik/tensor_gradient.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_ik.cpp
+++ b/pymomentum/tensor_ik/tensor_ik.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_ik.h"
 

--- a/pymomentum/tensor_ik/tensor_ik.h
+++ b/pymomentum/tensor_ik/tensor_ik.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_ik_utility.cpp
+++ b/pymomentum/tensor_ik/tensor_ik_utility.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_ik_utility.h"
 

--- a/pymomentum/tensor_ik/tensor_ik_utility.h
+++ b/pymomentum/tensor_ik/tensor_ik_utility.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_limit_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_limit_error_function.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_limit_error_function.h"
 

--- a/pymomentum/tensor_ik/tensor_limit_error_function.h
+++ b/pymomentum/tensor_ik/tensor_limit_error_function.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_marker_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_marker_error_function.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_marker_error_function.h"
 

--- a/pymomentum/tensor_ik/tensor_marker_error_function.h
+++ b/pymomentum/tensor_ik/tensor_marker_error_function.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_motion_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_motion_error_function.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_motion_error_function.h"
 

--- a/pymomentum/tensor_ik/tensor_motion_error_function.h
+++ b/pymomentum/tensor_ik/tensor_motion_error_function.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_pose_prior_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_pose_prior_error_function.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_pose_prior_error_function.h"
 

--- a/pymomentum/tensor_ik/tensor_pose_prior_error_function.h
+++ b/pymomentum/tensor_ik/tensor_pose_prior_error_function.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_projection_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_projection_error_function.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_projection_error_function.h"
 

--- a/pymomentum/tensor_ik/tensor_projection_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_projection_error_function.cpp
@@ -2,12 +2,12 @@
 
 #include "pymomentum/tensor_ik/tensor_projection_error_function.h"
 
-#include "pymomentum/nimble/tensor_camera/camera_utility.h"
 #include "pymomentum/tensor_ik/tensor_error_function_utility.h"
 
 #include <momentum/character/character.h>
 #include <momentum/character_solver/projection_error_function.h>
 #include <momentum/diff_ik/fully_differentiable_projection_error_function.h>
+
 namespace pymomentum {
 
 using momentum::FullyDifferentiableProjectionErrorFunction;

--- a/pymomentum/tensor_ik/tensor_projection_error_function.h
+++ b/pymomentum/tensor_ik/tensor_projection_error_function.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_residual.cpp
+++ b/pymomentum/tensor_ik/tensor_residual.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_residual.h"
 

--- a/pymomentum/tensor_ik/tensor_residual.h
+++ b/pymomentum/tensor_ik/tensor_residual.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/tensor_ik/tensor_vertex_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_vertex_error_function.cpp
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "pymomentum/tensor_ik/tensor_vertex_error_function.h"
 

--- a/pymomentum/tensor_ik/tensor_vertex_error_function.h
+++ b/pymomentum/tensor_ik/tensor_vertex_error_function.h
@@ -1,4 +1,9 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/pymomentum/test/test_quaternion.py
+++ b/pymomentum/test/test_quaternion.py
@@ -197,7 +197,7 @@ class TestQuaternion(unittest.TestCase):
         q = quaternion.from_two_vectors(v1, v2)
         rotated_v1 = quaternion.rotate_vector(q, v1)
 
-        self.assertTrue(torch.allclose(rotated_v1, v2))
+        self.assertTrue(torch.allclose(rotated_v1, v2, rtol=1e-4, atol=1e-6))
 
     def test_from_two_vectors_opposite(self):
         # Test with two opposite vectors
@@ -220,7 +220,5 @@ class TestQuaternion(unittest.TestCase):
         self.assertTrue(torch.allclose(rotated_v1, v1))
 
 
-if __name__ == "__main__":
-    unittest.main()
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary: Now that the internal dependencies have been removed from the tensor_ik and solver targets, they can be exposed on GitHub

Differential Revision: D70250178
