### PR TITLE
Add tensor_ik and solver targets

### DIFF
--- a/cmake/mt_defs.cmake
+++ b/cmake/mt_defs.cmake
@@ -433,6 +433,7 @@ function(mt_python_binding)
   )
   set(oneValueArgs
     NAME
+    MODULE_NAME
   )
   set(multiValueArgs
     HEADERS
@@ -485,6 +486,13 @@ function(mt_python_binding)
   target_compile_features(${_ARG_NAME} PRIVATE cxx_std_17)
   target_link_libraries(${_ARG_NAME} PRIVATE ${_ARG_LINK_LIBRARIES})
   target_compile_options(${_ARG_NAME} PRIVATE ${_ARG_COMPILE_OPTIONS})
+
+  if(NOT _ARG_MODULE_NAME)
+    set(_ARG_MODULE_NAME ${_ARG_NAME})
+  endif()
+  set_target_properties(${_ARG_NAME} PROPERTIES
+    OUTPUT_NAME "${_ARG_MODULE_NAME}"
+  )
 
   if(NOT ${_ARG_EXCLUDE_FROM_INSTALL})
     set_property(GLOBAL APPEND PROPERTY PYMOMENTUM_TARGETS_TO_INSTALL ${_ARG_NAME})

--- a/pixi.toml
+++ b/pixi.toml
@@ -204,15 +204,7 @@ build_py = { cmd = "pip install . -vv", env = { FBXSDK_PATH = ".deps/fbxsdk", CM
 """, MOMENTUM_ENABLE_SIMD = "ON" }, depends-on = [
     "install_deps",
 ] }
-test_py = { cmd = """
-    pytest \
-        pymomentum/test/test_closest_points.py \
-        pymomentum/test/test_fbx.py \
-        pymomentum/test/test_parameter_transform.py \
-        pymomentum/test/test_quaternion.py \
-        pymomentum/test/test_skel_state.py \
-        pymomentum/test/test_skeleton.py
-    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
+test_py = { cmd = "pytest pymomentum/test/*.py", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",
 ] }
 install_py = { cmd = "pip install -e ." }
@@ -237,15 +229,8 @@ build_py = { cmd = "pip install . -vv", env = { CMAKE_ARGS = """
     -DMOMENTUM_BUILD_IO_FBX=$MOMENTUM_BUILD_IO_FBX \
     -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD
 """, MOMENTUM_BUILD_IO_FBX = "OFF", MOMENTUM_ENABLE_SIMD = "ON" } }
-test_py = { cmd = """
-    pytest \
-        pymomentum/test/test_closest_points.py \
-        pymomentum/test/test_fbx.py \
-        pymomentum/test/test_parameter_transform.py \
-        pymomentum/test/test_quaternion.py \
-        pymomentum/test/test_skel_state.py \
-        pymomentum/test/test_skeleton.py
-    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
+# TODO: Remove -k option, once this tests are disabled programmatically if momentum is not built with FBX support
+test_py = { cmd = "pytest pymomentum/test/*.py -k 'not (TestFBXIO and (test_save_motions_with_joint_params or test_save_motions_with_model_params))'", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",
 ] }
 install_py = { cmd = "pip install -e ." }
@@ -270,15 +255,8 @@ build_py = { cmd = "pip install . -vv", env = { CMAKE_ARGS = """
     -DMOMENTUM_BUILD_IO_FBX=$MOMENTUM_BUILD_IO_FBX \
     -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD
 """, MOMENTUM_BUILD_IO_FBX = "OFF", MOMENTUM_ENABLE_SIMD = "ON" } }
-test_py = { cmd = """
-    pytest \
-        pymomentum/test/test_closest_points.py \
-        pymomentum/test/test_fbx.py \
-        pymomentum/test/test_parameter_transform.py \
-        pymomentum/test/test_quaternion.py \
-        pymomentum/test/test_skel_state.py \
-        pymomentum/test/test_skeleton.py
-    """, env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
+# TODO: Remove -k option, once this tests are disabled programmatically if momentum is not built with FBX support
+test_py = { cmd = "pytest pymomentum/test/*.py -k 'not (TestFBXIO and (test_save_motions_with_joint_params or test_save_motions_with_model_params))'", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",
 ] }
 install_py = { cmd = "pip install -e ." }

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -83,16 +83,38 @@ mt_library(
   PUBLIC_INCLUDE_DIRECTORIES
     ${ATEN_INCLUDE_DIR}
   PRIVATE_INCLUDE_DIRECTORIES
-    ${TORCH_LIBRARIES}
+    ${TORCH_INCLUDE_DIRS}
   PUBLIC_LINK_LIBRARIES
     momentum
+    diff_ik
     ${ATEN_LIBRARIES}
     pybind11::pybind11
   PRIVATE_LINK_LIBRARIES
     python_utility
     tensor_utility
-    axel
     Ceres::ceres
+    Dispenso::dispenso
+    Eigen3::Eigen
+    ${TORCH_LIBRARIES}
+    ${torch_python}
+  PUBLIC_COMPILE_OPTIONS
+    ${TORCH_CXX_FLAGS}
+  EXCLUDE_FROM_INSTALL
+)
+
+mt_library(
+  NAME tensor_ik
+  PYMOMENTUM_HEADERS_VARS tensor_ik_public_headers
+  PYMOMENTUM_SOURCES_VARS tensor_ik_sources
+  PUBLIC_INCLUDE_DIRECTORIES
+    ${ATEN_INCLUDE_DIR}
+    ${TORCH_INCLUDE_DIRS}
+  PUBLIC_LINK_LIBRARIES
+    momentum
+    diff_ik
+    ${ATEN_LIBRARIES}
+  PRIVATE_LINK_LIBRARIES
+    tensor_utility
     Dispenso::dispenso
     Eigen3::Eigen
     ${TORCH_LIBRARIES}
@@ -108,7 +130,7 @@ mt_python_binding(
   PYMOMENTUM_SOURCES_VARS geometry_sources
   INCLUDE_DIRECTORIES
     ${ATEN_INCLUDE_DIR}
-    ${TORCH_LIBRARIES}
+    ${TORCH_INCLUDE_DIRS}
   LINK_LIBRARIES
     character
     character_test_helpers
@@ -120,6 +142,29 @@ mt_python_binding(
     io_skeleton
     io_urdf
     python_utility
+    tensor_momentum
+    tensor_utility
+    ${ATEN_LIBRARIES}
+    ${TORCH_LIBRARIES}
+    ${torch_python}
+  COMPILE_OPTIONS
+    ${TORCH_CXX_FLAGS}
+)
+
+mt_python_binding(
+  NAME pymomentum_solver
+  MODULE_NAME solver
+  PYMOMENTUM_HEADERS_VARS solver_public_headers
+  PYMOMENTUM_SOURCES_VARS solver_sources
+  INCLUDE_DIRECTORIES
+    ${ATEN_INCLUDE_DIR}
+    ${TORCH_INCLUDE_DIRS}
+  LINK_LIBRARIES
+    character_solver
+    math
+    skeleton
+    python_utility
+    tensor_ik
     tensor_momentum
     tensor_utility
     ${ATEN_LIBRARIES}
@@ -164,6 +209,15 @@ if(MOMENTUM_BUILD_TESTING)
     NAME tensor_utility_test
     PYMOMENTUM_SOURCES_VARS tensor_utility_test_sources
     LINK_LIBRARIES tensor_utility
+  )
+
+  mt_test(
+    NAME tensor_ik_test
+    PYMOMENTUM_SOURCES_VARS tensor_ik_test_sources
+    LINK_LIBRARIES
+      character_test_helpers
+      tensor_ik
+      tensor_utility
   )
 endif()
 

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -50,6 +50,46 @@ tensor_momentum_sources = [
     "tensor_momentum/tensor_transforms.cpp",
 ]
 
+tensor_ik_public_headers = [
+    "tensor_ik/solver_options.h",
+    "tensor_ik/tensor_collision_error_function.h",
+    "tensor_ik/tensor_diff_pose_prior_error_function.h",
+    "tensor_ik/tensor_distance_error_function.h",
+    "tensor_ik/tensor_error_function_utility.h",
+    "tensor_ik/tensor_error_function.h",
+    "tensor_ik/tensor_gradient.h",
+    "tensor_ik/tensor_ik_utility.h",
+    "tensor_ik/tensor_ik.h",
+    "tensor_ik/tensor_limit_error_function.h",
+    "tensor_ik/tensor_marker_error_function.h",
+    "tensor_ik/tensor_motion_error_function.h",
+    "tensor_ik/tensor_pose_prior_error_function.h",
+    "tensor_ik/tensor_projection_error_function.h",
+    "tensor_ik/tensor_residual.h",
+    "tensor_ik/tensor_vertex_error_function.h",
+]
+
+tensor_ik_sources = [
+    "tensor_ik/tensor_collision_error_function.cpp",
+    "tensor_ik/tensor_diff_pose_prior_error_function.cpp",
+    "tensor_ik/tensor_distance_error_function.cpp",
+    "tensor_ik/tensor_error_function.cpp",
+    "tensor_ik/tensor_gradient.cpp",
+    "tensor_ik/tensor_ik_utility.cpp",
+    "tensor_ik/tensor_ik.cpp",
+    "tensor_ik/tensor_limit_error_function.cpp",
+    "tensor_ik/tensor_marker_error_function.cpp",
+    "tensor_ik/tensor_motion_error_function.cpp",
+    "tensor_ik/tensor_pose_prior_error_function.cpp",
+    "tensor_ik/tensor_projection_error_function.cpp",
+    "tensor_ik/tensor_residual.cpp",
+    "tensor_ik/tensor_vertex_error_function.cpp",
+]
+
+tensor_ik_test_sources = [
+    "cpp_test/tensor_ik_test.cpp",
+]
+
 geometry_public_headers = [
     "geometry/momentum_geometry.h",
     "geometry/momentum_io.h",
@@ -59,6 +99,15 @@ geometry_sources = [
     "geometry/geometry_pybind.cpp",
     "geometry/momentum_geometry.cpp",
     "geometry/momentum_io.cpp",
+]
+
+solver_public_headers = [
+    "solver/momentum_ik.h",
+]
+
+solver_sources = [
+    "solver/momentum_ik.cpp",
+    "solver/solver_pybind.cpp",
 ]
 
 quaternion_sources = [

--- a/pymomentum/cpp_test/tensor_ik_test.cpp
+++ b/pymomentum/cpp_test/tensor_ik_test.cpp
@@ -64,7 +64,7 @@ at::Tensor concatBatch(std::vector<at::Tensor> tensors) {
   }
 
   const auto sizes = tensors[0].sizes();
-  std::vector<long> sizes_batch = {(long)tensors.size()};
+  std::vector<int64_t> sizes_batch = {(int64_t)tensors.size()};
   std::copy(
       std::begin(sizes), std::end(sizes), std::back_inserter(sizes_batch));
 

--- a/pymomentum/doc/index.rst
+++ b/pymomentum/doc/index.rst
@@ -8,4 +8,5 @@ Welcome to PyMomentum
    geometry
    quaternion
    skel_state
+   solver
    marker_tracking

--- a/pymomentum/doc/solver.rst
+++ b/pymomentum/doc/solver.rst
@@ -1,0 +1,7 @@
+pymomentum.solver
+=================
+
+.. automodule:: pymomentum.solver
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pymomentum/quaternion.py
+++ b/pymomentum/quaternion.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the

--- a/pymomentum/skel_state.py
+++ b/pymomentum/skel_state.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Sequence
 
 import torch

--- a/pymomentum/solver/momentum_ik.h
+++ b/pymomentum/solver/momentum_ik.h
@@ -14,6 +14,7 @@
 
 #include <ATen/ATen.h>
 #include <pybind11/pybind11.h>
+#include <torch/extension.h> // @manual=//caffe2:torch_extension
 #include <torch/torch.h>
 
 #include <optional>

--- a/pymomentum/solver/solver_pybind.cpp
+++ b/pymomentum/solver/solver_pybind.cpp
@@ -14,6 +14,7 @@
 #include <dispenso/parallel_for.h> // @manual
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include <Eigen/Core>
 
 namespace py = pybind11;

--- a/pymomentum/test/test_fbx_io.py
+++ b/pymomentum/test/test_fbx_io.py
@@ -25,6 +25,7 @@ class TestFBXIO(unittest.TestCase):
         self.joint_params = self.character.parameter_transform.apply(self.model_params)
 
     def test_save_motions_with_model_params(self) -> None:
+        # TODO: Disable this test programmatically if momentum is not built with FBX support
         # Test saving with model parameters
         with tempfile.NamedTemporaryFile(suffix=".fbx") as temp_file:
             offsets = np.zeros(self.joint_params.shape[1])
@@ -55,6 +56,7 @@ class TestFBXIO(unittest.TestCase):
             self._verify_fbx(temp_file.name)
 
     def test_save_motions_with_joint_params(self) -> None:
+        # TODO: Disable this test programmatically if momentum is not built with FBX support
         # Test saving with joint parameters
         with tempfile.NamedTemporaryFile(suffix=".fbx") as temp_file:
             pym_geometry.Character.save_fbx_with_joint_params(

--- a/pymomentum/test/test_pose_prior.py
+++ b/pymomentum/test/test_pose_prior.py
@@ -10,7 +10,6 @@ import unittest
 import pymomentum.geometry as pym_geometry
 import pymomentum.solver as pym_solver
 import torch
-from __manifest__ import fbmake
 from pymomentum.solver import ErrorFunctionType
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -19,10 +18,6 @@ logger: logging.Logger = logging.getLogger(__name__)
 class TestPosePrior(unittest.TestCase):
     def test_ik_pose_prior(self) -> None:
         """Test solve_ik() with just the pose prior and positions."""
-
-        if fbmake["build_mode"] == "dev":
-            logger.info("This test is too slow in dev mode. Skip it.")
-            return
 
         # The mesh is a made by a few vertices on the line segment from (1,0,0) to (1,1,0)
         # and a few dummy faces.


### PR DESCRIPTION
Summary: Now that the internal dependencies have been removed from the tensor_ik and solver targets, they can be exposed on GitHub. This is needed to enable running IK on GitHub.

Differential Revision: D70250178
