### PR TITLE
Fix indentation warning

### DIFF
--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -878,9 +878,9 @@ parameters rather than joints.  Does not modify the parameter transform.  This i
 :param ancestor_joint_index: The index of a possible ancestor joint.
 
 :return: true if ancestorJointId is an ancestor of jointId; that is,
-if jointId is in the tree rooted at ancestorJointId.
-Note that a joint is considered to be its own ancestor; that is,
-isAncestor(id, id) returns true. )",
+    if jointId is in the tree rooted at ancestorJointId.
+    Note that a joint is considered to be its own ancestor; that is,
+    isAncestor(id, id) returns true. )",
           py::arg("joint_index"),
           py::arg("ancestor_joint_index"))
       .def_property_readonly(


### PR DESCRIPTION
Summary:
Sphinx complains about the incorrect indentation of a docstring:

```
docstring of pymomentum.geometry.PyCapsule.is_ancestor:7: WARNING: Field list ends without a blank line; unexpected unindent. [docutils]
WARNING: autodoc: failed to import module 'solver' from module 'pymomentum'; the following exception was raised:
['Traceback (most recent call last):\n', '  File "/home/runner/work/momentum/momentum/.pixi/envs/cpu/lib/python3.12/site-packages/sphinx/ext/autodoc/importer.py", line 269, in import_object\n    module = import_module(modname, try_reload=True)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n', '  File "/home/runner/work/momentum/momentum/.pixi/envs/cpu/lib/python3.12/site-packages/sphinx/ext/autodoc/importer.py", line 175, in import_module\n    module = importlib.import_module(modname)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n', '  File "/home/runner/work/momentum/momentum/.pixi/envs/cpu/lib/python3.12/importlib/__init__.py", line 90, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n', '  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import\n', '  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load\n', '  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_u
looking for now-outdated files... none found
pickling environment... done
/home/runner/work/momentum/momentum/pymomentum/doc/solver.rst: WARNING: document isn't included in any toctree [toc.not_included]
```

Differential Revision: D70324777


