### PR TITLE
Fix segfault of marker_tracking.process_markers() on macOS x86

### DIFF
--- a/momentum/test/character_solver/error_functions_test.cpp
+++ b/momentum/test/character_solver/error_functions_test.cpp
@@ -622,7 +622,7 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, VertexErrorFunction) {
             character_orig.skeleton,
             character_orig.parameterTransform.cast<T>(),
             errorTol,
-            Eps<T>(1e-6f, 1e-15),
+            Eps<T>(1e-6f, 1e-14),
             true,
             false);
       }

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -221,7 +221,7 @@ PYBIND11_MODULE(marker_tracking, m) {
 
         // python and cpp have the motion matrix transposed from each other:
         // python (#frames, #params) vs. cpp (#params, #frames)
-        return motion.transpose();
+        return motion.transpose().eval();
       },
       R"(process markers given character and identity.
 


### PR DESCRIPTION
## Summary

Fix segfault reported in https://github.com/facebookincubator/momentum/actions/runs/13845045528/job/38809455318#step:5:1756

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

CI
