### PR TITLE
Remove use of deprecated gsl::byte

### DIFF
--- a/momentum/io/common/gsl_utils.h
+++ b/momentum/io/common/gsl_utils.h
@@ -23,7 +23,7 @@ namespace momentum {
 ///
 /// @return A span of the new type, with the same number of elements as the original span
 template <typename T>
-[[nodiscard]] gsl::span<T> cast_span(gsl::span<gsl::byte> bs) {
+[[nodiscard]] gsl::span<T> cast_span(gsl::span<std::byte> bs) {
   auto ptr = reinterpret_cast<T*>(bs.data());
   auto tsize = gsl::narrow<decltype(bs)::size_type>(sizeof(T));
   return {ptr, bs.size_bytes() / tsize};
@@ -41,7 +41,7 @@ template <typename T>
 ///
 /// @return A span of the new type, with the same number of elements as the original span
 template <typename T>
-[[nodiscard]] gsl::span<const T> cast_span(gsl::span<const gsl::byte> bs) {
+[[nodiscard]] gsl::span<const T> cast_span(gsl::span<const std::byte> bs) {
   auto ptr = reinterpret_cast<const T*>(bs.data());
   auto tsize = gsl::narrow<decltype(bs)::size_type>(sizeof(T));
   return {ptr, bs.size_bytes() / tsize};


### PR DESCRIPTION
Summary:
`gsl::byte` has been equivalent since C++17:


https://www.internalfb.com/code/fbsource/[014e8e1ba1ee]/third-party/gsl/include/gsl/byte?lines=64-103

and was deprecated in gsl 4.2.0, which emits warnings as ([build log](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1203792&view=logs&j=d6b58996-039f-5e48-56bf-c3a016e5cd7f)):

```
In file included from /Users/runner/miniforge3/conda-bld/momentum_1742487339260/work/momentum/io/openfbx/openfbx_io.cpp:15:
  /Users/runner/miniforge3/conda-bld/momentum_1742487339260/work/momentum/io/common/gsl_utils.h:26:53: warning: 'byte' is deprecated: Use std::byte instead. [-Wdeprecated-declarations]
     26 | [[nodiscard]] gsl::span<T> cast_span(gsl::span<gsl::byte> bs) {
        |                                                     ^
  /Users/runner/miniforge3/conda-bld/momentum_1742487339260/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/gsl/./././byte:91:12: note: 'byte' has been explicitly marked deprecated here
     91 | using byte GSL_DEPRECATED("Use std::byte instead.") = std::byte;
        |            ^
  /Users/runner/miniforge3/conda-bld/momentum_1742487339260/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/gsl/././././util:65:31: note: expanded from macro 'GSL_DEPRECATED'
     65 | #define GSL_DEPRECATED(msg) [[deprecated(msg)]]
        |                               ^
  In file included from /Users/runner/miniforge3/conda-bld/momentum_1742487339260/work/momentum/io/openfbx/openfbx_io.cpp:15:
  /Users/runner/miniforge3/conda-bld/momentum_1742487339260/work/momentum/io/common/gsl_utils.h:44:65: warning: 'byte' is deprecated: Use std::byte instead. [-Wdeprecated-declarations]
     44 | [[nodiscard]] gsl::span<const T> cast_span(gsl::span<const gsl::byte> bs) {
        |                                                                 ^
  /Users/runner/miniforge3/conda-bld/momentum_1742487339260/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/gsl/./././byte:91:12: note: 'byte' has been explicitly marked deprecated here
     91 | using byte GSL_DEPRECATED("Use std::byte instead.") = std::byte;
        |            ^
  /Users/runner/miniforge3/conda-bld/momentum_1742487339260/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/gsl/././././util:65:31: note: expanded from macro 'GSL_DEPRECATED'
     65 | #define GSL_DEPRECATED(msg) [[deprecated(msg)]]
        |                               ^
```

Differential Revision: D71561855


