### PR TITLE
Resolve pytest warnings

### DIFF
--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -2320,7 +2320,7 @@ Computes vertex normals for a triangle mesh given its positions.
 
   // createTestCharacter()
   m.def(
-      "test_character",
+      "create_test_character",
       &momentum::createTestCharacter<float>,
       R"(Create a simple 3-joint test character.  This is useful for writing confidence tests that
 execute quickly and don't rely on outside files.

--- a/pymomentum/test/test_blend_shape.py
+++ b/pymomentum/test/test_blend_shape.py
@@ -41,7 +41,7 @@ class TestBlendShape(unittest.TestCase):
 
         nBatch = 2
         n_coeffs = min(blend_shape.n_shapes, 10)
-        coeffs = torch.rand(nBatch, n_coeffs, requires_grad=True)
+        coeffs = torch.rand(nBatch, n_coeffs, dtype=torch.float64, requires_grad=True)
 
         shape1 = blend_shape.compute_shape(coeffs).select(0, 0)
         c1 = coeffs.select(0, 0).detach().numpy()
@@ -64,7 +64,7 @@ class TestBlendShape(unittest.TestCase):
         torch.manual_seed(0)  # ensure repeatability
         np.random.seed(0)
 
-        c = pym_geometry.test_character()
+        c = pym_geometry.create_test_character()
 
         # Build a blend shape basis:
         blend_shape = _build_blend_shape_basis(c)
@@ -78,7 +78,7 @@ class TestBlendShape(unittest.TestCase):
     def test_skinning_compare_momentum(self) -> None:
         """Compare the pymomentum skinning against the native momentum skinning."""
 
-        c = pym_geometry.test_character()
+        c = pym_geometry.create_test_character()
         torch.manual_seed(0)  # ensure repeatability
         n_model_params = c.parameter_transform.size
 
@@ -99,7 +99,7 @@ class TestBlendShape(unittest.TestCase):
 
         torch.set_printoptions(profile="full")
 
-        c = pym_geometry.test_character()
+        c = pym_geometry.create_test_character()
         torch.manual_seed(0)  # ensure repeatability
         n_model_params = c.parameter_transform.size
 
@@ -134,7 +134,7 @@ class TestBlendShape(unittest.TestCase):
         )
 
     def test_solve_blend_shape(self) -> None:
-        c = pym_geometry.test_character()
+        c = pym_geometry.create_test_character()
         blend_shape = _build_blend_shape_basis(c)
         c = c.with_blend_shape(blend_shape)
         pt = c.parameter_transform

--- a/pymomentum/test/test_fbx_io.py
+++ b/pymomentum/test/test_fbx_io.py
@@ -14,7 +14,7 @@ import torch
 
 class TestFBXIO(unittest.TestCase):
     def setUp(self) -> None:
-        self.character = pym_geometry.test_character()
+        self.character = pym_geometry.create_test_character()
         torch.manual_seed(0)  # ensure repeatability
 
         nBatch = 5

--- a/pymomentum/test/test_parameter_transform.py
+++ b/pymomentum/test/test_parameter_transform.py
@@ -10,14 +10,14 @@ import unittest
 import torch
 from pymomentum.geometry import (
     Character,
-    test_character,
+    create_test_character,
     uniform_random_to_model_parameters,
 )
 
 
 class TestParameterTransform(unittest.TestCase):
     def test_get_transform(self) -> None:
-        character: Character = test_character()
+        character: Character = create_test_character()
         transform = character.parameter_transform.transform
         self.assertEqual(tuple(transform.shape), (3 * 7, 10))
 

--- a/pymomentum/test/test_pose_prior.py
+++ b/pymomentum/test/test_pose_prior.py
@@ -21,7 +21,7 @@ class TestPosePrior(unittest.TestCase):
 
         # The mesh is a made by a few vertices on the line segment from (1,0,0) to (1,1,0)
         # and a few dummy faces.
-        character = pym_geometry.test_character()
+        character = pym_geometry.create_test_character()
 
         n_joints = character.skeleton.size
         n_params = character.parameter_transform.size

--- a/pymomentum/test/test_process_markers.py
+++ b/pymomentum/test/test_process_markers.py
@@ -118,7 +118,7 @@ class TestMarkerTracker(unittest.TestCase):
         )
 
     def test_motion_matrix(self) -> None:
-        character = pym_geometry.test_character()
+        character = pym_geometry.create_test_character()
         tracking_config = TrackingConfig()
         calibration_config = CalibrationConfig()
         refine_config = RefineConfig()

--- a/pymomentum/test/test_sequence_ik.py
+++ b/pymomentum/test/test_sequence_ik.py
@@ -20,7 +20,7 @@ class TestSolver(unittest.TestCase):
 
         # The mesh is a made by a few vertices on the line segment from (1,0,0) to (1,1,0)
         # and a few dummy faces.
-        character = pym_geometry.test_character()
+        character = pym_geometry.create_test_character()
 
         n_joints = character.skeleton.size
         n_params = character.parameter_transform.size

--- a/pymomentum/test/test_skel_state.py
+++ b/pymomentum/test/test_skel_state.py
@@ -49,7 +49,7 @@ def generate_random_skel_state(sz: int) -> torch.Tensor:
 
 class TestSkelState(unittest.TestCase):
     def test_skel_state_to_transforms(self) -> None:
-        character = pym_geometry.test_character()
+        character = pym_geometry.create_test_character()
         nBatch = 2
         modelParams = 0.2 * torch.ones(
             nBatch,

--- a/pymomentum/test/test_skeleton.py
+++ b/pymomentum/test/test_skeleton.py
@@ -7,12 +7,12 @@
 
 import unittest
 
-from pymomentum.geometry import Character, test_character
+from pymomentum.geometry import Character, create_test_character
 
 
 class TestSkeleton(unittest.TestCase):
     def test_get_skeleton_offsets_and_prerotations(self) -> None:
-        char: Character = test_character()
+        char: Character = create_test_character()
         offsets = char.skeleton.offsets
         pre_rotations = char.skeleton.pre_rotations
         num_joints = len(char.skeleton.joint_names)

--- a/pymomentum/test/test_solver.py
+++ b/pymomentum/test/test_solver.py
@@ -19,7 +19,7 @@ from pymomentum.solver import ErrorFunctionType
 
 
 def solve_one_ik_problem(index: int) -> torch.Tensor:
-    character = pym_geometry.test_character()
+    character = pym_geometry.create_test_character()
 
     n_joints = character.skeleton.size
     n_params = character.parameter_transform.size
@@ -79,7 +79,7 @@ class TestSolver(unittest.TestCase):
 
         # The mesh is a made by a few vertices on the line segment from (1,0,0) to (1,1,0)
         # and a few dummy faces.
-        character = pym_geometry.test_character()
+        character = pym_geometry.create_test_character()
 
         n_joints = character.skeleton.size
         n_params = character.parameter_transform.size
@@ -244,7 +244,7 @@ class TestSolver(unittest.TestCase):
 
         # The mesh is a made by a few vertices on the line segment from (1,0,0) to (1,1,0)
         # and a few dummy faces.
-        character = pym_geometry.test_character()
+        character = pym_geometry.create_test_character()
 
         n_joints = character.skeleton.size
         n_params = character.parameter_transform.size
@@ -273,7 +273,7 @@ class TestSolver(unittest.TestCase):
         self.assertTrue(result.allclose(model_params_init, atol=1e-8))
 
     def test_gradient(self) -> None:
-        character = pym_geometry.test_character()
+        character = pym_geometry.create_test_character()
 
         n_joints = character.skeleton.size
         n_params = character.parameter_transform.size
@@ -366,7 +366,7 @@ class TestSolver(unittest.TestCase):
         )
 
     def test_residual(self) -> None:
-        character = pym_geometry.test_character()
+        character = pym_geometry.create_test_character()
 
         n_joints = character.skeleton.size
         n_params = character.parameter_transform.size
@@ -479,7 +479,7 @@ class TestSolver(unittest.TestCase):
 
         # The mesh is a made by a few vertices on the line segment from (1,0,0) to (1,1,0)
         # and a few dummy faces.
-        character = pym_geometry.test_character()
+        character = pym_geometry.create_test_character()
 
         n_joints = character.skeleton.size
         n_params = character.parameter_transform.size
@@ -558,7 +558,7 @@ class TestSolver(unittest.TestCase):
 
         # The mesh is a made by a few vertices on the line segment from (1,0,0) to (1,1,0)
         # and a few dummy faces.
-        character = pym_geometry.test_character()
+        character = pym_geometry.create_test_character()
 
         n_joints = character.skeleton.size
         n_params = character.parameter_transform.size
@@ -626,7 +626,7 @@ class TestSolver(unittest.TestCase):
         self.assertEqual(n_solve_iter, 6)
 
     def test_transform_pose(self) -> None:
-        character = pym_geometry.test_character()
+        character = pym_geometry.create_test_character()
         torch.manual_seed(0)  # ensure repeatability
 
         nBatch = 5


### PR DESCRIPTION
## Summary

```
.:0
.:0
  :0: PytestCollectionWarning: cannot collect 'test_character' because it is not a function.

pymomentum/test/test_blend_shape.py::TestBlendShape::test_diffApplyBlendCoeffs
  C:\Users\jeongseok\dev\momentum\main\.pixi\envs\gpu\Lib\site-packages\torch\autograd\gradcheck.py:922: UserWarning: Input #0 requires gradient and is not a double precision floating point or complex. This check will likely fail if all the inputs are not of double precision floating point or complex.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookincubator.github.io/momentum/docs/developer_guide/style_guide)
- [ ] Codebase formatted by running `pixi run lint`

## Test Plan

Run pytest, confirming no warnings:

```
pixi run test_py
```
