### PR TITLE
New skeleton functionality.

### DIFF
--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -774,6 +774,11 @@ parameters rather than joints.  Does not modify the parameter transform.  This i
           },
           "Returns the pre-rotation for this joint in default pose of the character. Quaternion format: (x, y, z, w)")
       .def_property_readonly(
+          "pre_rotation_matrix",
+          [](const mm::Joint& joint) {
+            return joint.preRotation.toRotationMatrix();
+          })
+      .def_property_readonly(
           "translation_offset",
           [](const mm::Joint& joint) { return joint.translationOffset; },
           "Returns the translation offset for this joint in default pose of the character.");
@@ -914,7 +919,8 @@ parameters rather than joints.  Does not modify the parameter transform.  This i
                 });
             return pymomentum::asArray(preRotations);
           },
-          "Returns skeleton joint offsets tensor for all joints shape: (num_joints, 4)");
+          "Returns skeleton joint offsets tensor for all joints shape: (num_joints, 4)")
+      .def_readonly("joints", &mm::Skeleton::joints);
 
   // =====================================================
   // momentum::SkinWeights

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -775,7 +775,7 @@ parameters rather than joints.  Does not modify the parameter transform.  This i
           "Returns the pre-rotation for this joint in default pose of the character. Quaternion format: (x, y, z, w)")
       .def_property_readonly(
           "translation_offset",
-          [](const mm::Joint& joint) { return joint.name; },
+          [](const mm::Joint& joint) { return joint.translationOffset; },
           "Returns the translation offset for this joint in default pose of the character.");
 
   // =====================================================


### PR DESCRIPTION
Summary:
I recently realized we pybinded the Joint structure but we never provided access to it through the Skeleton, I see no reason not to.  

Also adding a method to access pre-rotation as a matrix so I don't have to remember quaternion order.

Reviewed By: jeongseok-meta

Differential Revision: D71385856


