### PR TITLE
Return barycentric coordinates from closest surface point query

### DIFF
--- a/axel/axel/BvhCommon.h
+++ b/axel/axel/BvhCommon.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <Eigen/Core>
 
 namespace axel {
@@ -30,6 +32,9 @@ template <typename S>
 struct ClosestSurfacePointResult {
   Eigen::Vector3<S> point;
   uint32_t triangleIdx = kInvalidTriangleIdx;
+
+  // TODO: Remove optional once all the queries support barycentric coordinates.
+  std::optional<Eigen::Vector3<S>> baryCoords;
 };
 
 using ClosestSurfacePointResultf = ClosestSurfacePointResult<float>;

--- a/axel/axel/math/PointTriangleProjection.cpp
+++ b/axel/axel/math/PointTriangleProjection.cpp
@@ -17,13 +17,15 @@ template bool projectOnTriangle(
     const Eigen::Vector3<float>& a,
     const Eigen::Vector3<float>& b,
     const Eigen::Vector3<float>& c,
-    Eigen::Vector3<float>& q);
+    Eigen::Vector3<float>& q,
+    Eigen::Vector3<float>* barycentric);
 template bool projectOnTriangle(
     const Eigen::Vector3<double>& p,
     const Eigen::Vector3<double>& a,
     const Eigen::Vector3<double>& b,
     const Eigen::Vector3<double>& c,
-    Eigen::Vector3<double>& q);
+    Eigen::Vector3<double>& q,
+    Eigen::Vector3<double>* barycentric);
 
 #define INSTANTIATE_PROJECT_ON_TRIANGLE(Scalar)            \
   template WideMask<WideScalar<Scalar>> projectOnTriangle( \
@@ -31,7 +33,8 @@ template bool projectOnTriangle(
       const WideVec3<Scalar>& a,                           \
       const WideVec3<Scalar>& b,                           \
       const WideVec3<Scalar>& c,                           \
-      WideVec3<Scalar>& q);
+      WideVec3<Scalar>& q,                                 \
+      WideVec3<Scalar>* barycentric);
 
 INSTANTIATE_PROJECT_ON_TRIANGLE(float)
 INSTANTIATE_PROJECT_ON_TRIANGLE(double)

--- a/axel/axel/math/PointTriangleProjection.h
+++ b/axel/axel/math/PointTriangleProjection.h
@@ -19,7 +19,8 @@ bool projectOnTriangle(
     const Eigen::Vector3<S>& a,
     const Eigen::Vector3<S>& b,
     const Eigen::Vector3<S>& c,
-    Eigen::Vector3<S>& q);
+    Eigen::Vector3<S>& q,
+    Eigen::Vector3<S>* barycentric = nullptr);
 
 template <typename S>
 WideMask<WideScalar<S>> projectOnTriangle(
@@ -27,6 +28,7 @@ WideMask<WideScalar<S>> projectOnTriangle(
     const WideVec3<S>& a,
     const WideVec3<S>& b,
     const WideVec3<S>& c,
-    WideVec3<S>& q);
+    WideVec3<S>& q,
+    WideVec3<S>* barycentric = nullptr);
 
 } // namespace axel

--- a/axel/axel/test/TriBvhEmbreeTest.cpp
+++ b/axel/axel/test/TriBvhEmbreeTest.cpp
@@ -111,7 +111,8 @@ TYPED_TEST(TriBvhEmbreeTest, ClosestSurfacePoint_SameResultsAsIgl) {
     Eigen::RowVector3<S> p0;
     aabb.squared_distance(positions, faces, query, tri0, p0);
 
-    const auto [p1, tri1] = bvh.closestSurfacePoint(query);
+    const auto result = bvh.closestSurfacePoint(query);
+    const auto& p1 = result.point;
 
     EXPECT_NEAR(
         (query - Eigen::Vector3<S>(p0)).norm(), (query - p1).norm(), detail::eps<S>(1e-6, 1e-10))


### PR DESCRIPTION
Summary:
The closest surface point query currently returns only the projection point. However, it is sometimes useful to utilize the barycentric coordinates of the triangle primitive that are already computed in the query. This Diff aims to allow for the return of this value by adding a new field to the result struct.

The new field is declared as optional since it is not yet supported by all queries and accelerators.

Differential Revision: D72196845


