### PR TITLE
Add support for find_closest_points_on_mesh to pymomentum.

### DIFF
--- a/axel/CMakeLists.txt
+++ b/axel/CMakeLists.txt
@@ -30,6 +30,7 @@ set(headers
   axel/common/Constants.h
   axel/common/Types.h
   axel/common/VectorizationTypes.h
+  axel/math/BoundingBoxUtils.h
   axel/math/PointTriangleProjection.h
   axel/math/PointTriangleProjectionDefinitions.h
   axel/math/RayTriangleIntersection.h
@@ -37,7 +38,9 @@ set(headers
   axel/Bvh.h
   axel/BvhBase.h
   axel/BvhCommon.h
+  axel/Ray.h
   axel/SimdKdTree.h
+  axel/TriBvh.h
 )
 
 set(sources
@@ -46,6 +49,7 @@ set(sources
   axel/BoundingBox.cpp
   axel/Bvh.cpp
   axel/SimdKdTree.cpp
+  axel/TriBvh.cpp
 )
 
 target_sources(${target_name}

--- a/axel/axel/BvhCommon.h
+++ b/axel/axel/BvhCommon.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <Eigen/Core>
 
 namespace axel {
@@ -30,6 +32,9 @@ template <typename S>
 struct ClosestSurfacePointResult {
   Eigen::Vector3<S> point;
   uint32_t triangleIdx = kInvalidTriangleIdx;
+
+  // TODO: Remove optional once all the queries support barycentric coordinates.
+  std::optional<Eigen::Vector3<S>> baryCoords;
 };
 
 using ClosestSurfacePointResultf = ClosestSurfacePointResult<float>;

--- a/axel/axel/BvhEmbree.cpp
+++ b/axel/axel/BvhEmbree.cpp
@@ -9,10 +9,11 @@
 
 #include <utility>
 
-#include <bolt/analyzer/Tracer.h>
 #include <dispenso/parallel_for.h>
 
 #include <Eigen/Dense>
+
+#include "axel/Profile.h"
 
 #define DEFAULT_LOG_CHANNEL "AXEL: Embree"
 #include "axel/Log.h"
@@ -249,7 +250,7 @@ BVHEmbree& BVHEmbree::operator=(BVHEmbree&& other) noexcept {
 void BVHEmbree::setBoundingBoxes(const std::vector<BoundingBoxd>& bboxes) {
   std::vector<RTCBuildPrimitive> prims;
   {
-    BOLT_TRACE_TAG("BVHEmbree::convert_bbox_to_prims");
+    XR_PROFILE_EVENT("BVHEmbree::convert_bbox_to_prims");
     prims.reserve(bboxes.size() * 2);
     prims.resize(bboxes.size());
     dispenso::parallel_for(0, bboxes.size(), [&bboxes, &prims](const size_t i) {

--- a/axel/axel/TriBvh.cpp
+++ b/axel/axel/TriBvh.cpp
@@ -7,9 +7,9 @@
 
 #include "axel/TriBvh.h"
 
-#include <bolt/analyzer/Tracer.h>
 #include <expected/Expected.h>
 
+#include "axel/Profile.h"
 #include "axel/math/BoundingBoxUtils.h"
 #include "axel/math/PointTriangleProjection.h"
 
@@ -37,7 +37,7 @@ Bvh<S, LeafCapacity> buildBvh(
     const Eigen::MatrixX3<S>& positions,
     const Eigen::MatrixX3i& triangles,
     const std::optional<S>& boundingBoxThickness) {
-  BOLT_TRACE_TAG("build_bvh");
+  XR_PROFILE_EVENT("build_bvh");
   const Eigen::Index triangleCount{triangles.rows()};
   std::vector<BoundingBox<S>> boundingBoxes(triangleCount);
 

--- a/axel/axel/TriBvh.cpp
+++ b/axel/axel/TriBvh.cpp
@@ -7,8 +7,7 @@
 
 #include "axel/TriBvh.h"
 
-#include <expected/Expected.h>
-
+#include "axel/Checks.h"
 #include "axel/Profile.h"
 #include "axel/math/BoundingBoxUtils.h"
 #include "axel/math/PointTriangleProjection.h"
@@ -45,7 +44,7 @@ Bvh<S, LeafCapacity> buildBvh(
     const Eigen::Vector3i triangle = triangles.row(triangleIndex);
 
     const Eigen::Index positionCount{positions.rows()};
-    XRE_VERIFY_F(
+    XR_CHECK(
         triangle[0] < positionCount && triangle[1] < positionCount && triangle[2] < positionCount,
         "Triangle {} index out of bounds! It has vertices {}, {}, {}, but the last vertex is at {}.",
         triangleIndex,

--- a/axel/axel/math/PointTriangleProjection.cpp
+++ b/axel/axel/math/PointTriangleProjection.cpp
@@ -17,13 +17,15 @@ template bool projectOnTriangle(
     const Eigen::Vector3<float>& a,
     const Eigen::Vector3<float>& b,
     const Eigen::Vector3<float>& c,
-    Eigen::Vector3<float>& q);
+    Eigen::Vector3<float>& q,
+    Eigen::Vector3<float>* barycentric);
 template bool projectOnTriangle(
     const Eigen::Vector3<double>& p,
     const Eigen::Vector3<double>& a,
     const Eigen::Vector3<double>& b,
     const Eigen::Vector3<double>& c,
-    Eigen::Vector3<double>& q);
+    Eigen::Vector3<double>& q,
+    Eigen::Vector3<double>* barycentric);
 
 #define INSTANTIATE_PROJECT_ON_TRIANGLE(Scalar)            \
   template WideMask<WideScalar<Scalar>> projectOnTriangle( \
@@ -31,7 +33,8 @@ template bool projectOnTriangle(
       const WideVec3<Scalar>& a,                           \
       const WideVec3<Scalar>& b,                           \
       const WideVec3<Scalar>& c,                           \
-      WideVec3<Scalar>& q);
+      WideVec3<Scalar>& q,                                 \
+      WideVec3<Scalar>* barycentric);
 
 INSTANTIATE_PROJECT_ON_TRIANGLE(float)
 INSTANTIATE_PROJECT_ON_TRIANGLE(double)

--- a/axel/axel/math/PointTriangleProjection.h
+++ b/axel/axel/math/PointTriangleProjection.h
@@ -19,7 +19,8 @@ bool projectOnTriangle(
     const Eigen::Vector3<S>& a,
     const Eigen::Vector3<S>& b,
     const Eigen::Vector3<S>& c,
-    Eigen::Vector3<S>& q);
+    Eigen::Vector3<S>& q,
+    Eigen::Vector3<S>* barycentric = nullptr);
 
 template <typename S>
 WideMask<WideScalar<S>> projectOnTriangle(
@@ -27,6 +28,7 @@ WideMask<WideScalar<S>> projectOnTriangle(
     const WideVec3<S>& a,
     const WideVec3<S>& b,
     const WideVec3<S>& c,
-    WideVec3<S>& q);
+    WideVec3<S>& q,
+    WideVec3<S>* barycentric = nullptr);
 
 } // namespace axel

--- a/axel/axel/test/TriBvhEmbreeTest.cpp
+++ b/axel/axel/test/TriBvhEmbreeTest.cpp
@@ -111,7 +111,8 @@ TYPED_TEST(TriBvhEmbreeTest, ClosestSurfacePoint_SameResultsAsIgl) {
     Eigen::RowVector3<S> p0;
     aabb.squared_distance(positions, faces, query, tri0, p0);
 
-    const auto [p1, tri1] = bvh.closestSurfacePoint(query);
+    const auto result = bvh.closestSurfacePoint(query);
+    const auto& p1 = result.point;
 
     EXPECT_NEAR(
         (query - Eigen::Vector3<S>(p0)).norm(), (query - p1).norm(), detail::eps<S>(1e-6, 1e-10))

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -2295,6 +2295,23 @@ Using the normal is a good way to avoid certain kinds of bad matches, such as ma
       py::arg("max_normal_dot") = 0.0f);
 
   m.def(
+      "find_closest_points_on_mesh",
+      &findClosestPointsOnMesh,
+      R"(For each point in the points_source tensor, find the closest point in the target mesh.
+
+  :param points_source: [nBatch x nPoints x 3] tensor of source points.
+  :param vertices_target: [nBatch x nPoints x 3] tensor of target vertices.
+  :param faces_target: [nBatch x nPoints x 3] tensor of target faces.
+  :return: A tuple of three tensors, (valid, points, face_index, bary).  The first is [nBatch x nPoints] and specifies if the closest point result is valid.
+           The second is [nBatch x nPoints x 3] and contains the actual closest point (or 0, 0, 0 if invalid).
+           The third is [nBatch x nPoints] and contains the index of the closest face (or -1 if invalid).
+           The fourth is [nBatch x nPoints x 3] and contains the barycentric coordinates of the closest point on the face (or 0, 0, 0 if invalid).
+        )",
+      py::arg("points_source"),
+      py::arg("vertices_target"),
+      py::arg("faces_target"));
+
+  m.def(
       "replace_rest_mesh",
       &replaceRestMesh,
       R"(Return a new :class:`Character` with the rest mesh positions replaced by the passed-in positions.

--- a/pymomentum/tensor_momentum/tensor_kd_tree.h
+++ b/pymomentum/tensor_momentum/tensor_kd_tree.h
@@ -28,4 +28,10 @@ findClosestPointsWithNormals(
     float maxDist,
     float maxNormalDot);
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+findClosestPointsOnMesh(
+    at::Tensor points_source,
+    at::Tensor vertices_target,
+    at::Tensor faces_target);
+
 } // namespace pymomentum


### PR DESCRIPTION
Summary:
This is a mesh-based version of the old KdTree, which will be useful for doing surface queries.

I was considering doing this with numpy primitives instead of torch Tensors since it's not differentiable but for now I guess let's stick with torch Tensors for consistency with the existing closest_point functions, we can switch them all later if we want.

Reviewed By: jeongseok-meta

Differential Revision: D72259812


